### PR TITLE
Remove $CF_HOME/.cf, not $CF_HOME, which points to buildir

### DIFF
--- a/scripts/scf_clean.sh
+++ b/scripts/scf_clean.sh
@@ -28,7 +28,7 @@ if [[ $ENABLE_EIRINI == true ]] ; then
     helm del --purge metrics-server
 fi
 
-rm -rf scf-config-values.yaml chart.zip helm kube "$HELM_HOME" "$CF_HOME"
+rm -rf scf-config-values.yaml chart.zip helm kube "$HELM_HOME" "$CF_HOME"/.cf
 
 # delete CHART_URL on cap-values configmap
 kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "null"'


### PR DESCRIPTION
On `make clean-scf` we need to delete all HOMEs, including CF_HOME. While it's
true that CF_HOME defaults to ~, and cf looks for files in CF_HOME/.cf, if we
leave CF_HOME="$(pwd)" it points to the current dir and we cannot delete it.

If we don't fix this, on `make clean-scf`, the buildir gets deleted.

Let the cfcli config files be in buildir/.cf/cf