### PR TITLE
Add EKS as a backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ kind: clean buildir
 gke: clean buildir
 	make -C backend/gke
 
+.PHONY: eks
+eks: clean buildir
+	make -C backend/eks
+
 .PHONY: minikube
 minikube: clean buildir
 	make -C backend/minikube

--- a/backend/eks/Makefile
+++ b/backend/eks/Makefile
@@ -1,0 +1,24 @@
+.DEFAULT_GOAL := all
+
+.PHONY: kubeconfig
+kubeconfig:
+	# No-op
+
+.PHONY: deps-eks
+deps-eks:
+	./deps.sh
+
+.PHONY: eks-deploy
+eks-deploy:
+	./deploy.sh
+
+.PHONY: eks-prepare
+eks-prepare:
+	./prepare.sh
+
+.PHONY: clean
+clean:
+	./clean.sh
+
+.PHONY: all
+all: clean deps-eks eks-deploy eks-prepare

--- a/backend/eks/Makefile
+++ b/backend/eks/Makefile
@@ -21,4 +21,4 @@ clean:
 	./clean.sh
 
 .PHONY: all
-all: clean deps-eks eks-deploy eks-prepare
+all: deps-eks eks-deploy eks-prepare

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Requires:
+# - aws credentials present
+
+. ../../include/common.sh
+
+set -exuo pipefail
+
+
+if [ -d ../"$BUILD_DIR" ]; then
+    . .envrc
+
+    pushd cap-terraform/eks
+    terraform destroy -auto-approve
+    popd
+
+    popd
+    rm -rf "$BUILD_DIR"
+fi

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -8,12 +8,16 @@
 set -exuo pipefail
 
 
-if [ -d ../"$BUILD_DIR" ]; then
+if [ -d "$BUILD_DIR" ]; then
     . .envrc
 
-    pushd cap-terraform/eks
-    terraform destroy -auto-approve
-    popd
+
+    if [ -d "cap-terraform/eks" ]; then
+        pushd cap-terraform/eks
+        terraform destroy -auto-approve
+        popd
+        rm -rf cap-terraform
+    fi
 
     popd
     rm -rf "$BUILD_DIR"

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Requires:
+# - aws credentials present
+
+. ../../include/common.sh
+. .envrc
+
+set -Eexuo pipefail
+
+if ! aws sts get-caller-identity ; then
+    echo ">>> Missing aws credentials, run aws configure, aborting" && exit 1
+fi
+
+git clone https://github.com/SUSE/cap-terraform.git
+pushd cap-terraform/eks
+
+# terraform needs helm client installed and configured:
+helm init --client-only
+
+EKS_LOCATION="${EKS_LOCATION:-us-west-2}"
+EKS_KEYPAIR="${EKS_KEYPAIR:-$(whoami)-terraform}"
+EKS_VERS="${EKS_VERS:-1.14}"
+EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-{key = \"$(whoami)-eks-cluster\"}}
+cat <<HEREDOC > terraform.tfvars
+region = "$EKS_LOCATION"
+workstation_cidr_block = "0.0.0.0/0"
+keypair_name = "$EKS_KEYPAIR"
+eks_version = "$EKS_VERS"
+cluster_labels = $EKS_CLUSTER_LABEL
+HEREDOC
+
+terraform init
+
+terraform plan -out=my-plan
+
+terraform apply -auto-approve
+
+# get kubectl for eks:
+# aws eks --region "$EKS_LOCATION" update-kubeconfig --name "$EKS_CLUSTER_NAME"
+# or:
+terraform output kubeconfig > "$KUBECONFIG"
+
+# make worker nodes join:
+terraform output config_map_aws_auth > eks_cm.yaml
+kubectl apply -f eks_cm.yaml
+
+# wait for workers:
+while kubectl get nodes | grep "notReady" > /dev/null;
+do
+    sleep 10
+done
+
+# test deployment:
+kubectl get svc
+
+ROOTFS=overlay-xfs
+# take first worker node as public ip:
+PUBLIC_IP="$(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address' | head -n 1)"
+DOMAIN="$PUBLIC_IP.omg.howdoi.website"
+if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
+    kubectl create configmap -n kube-system cap-values \
+            --from-literal=garden-rootfs-driver="${ROOTFS}" \
+            --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=domain="${DOMAIN}" \
+            --from-literal=platform=eks
+fi
+
+create_rolebinding() {
+
+    kubectl create clusterrolebinding admin --clusterrole=cluster-admin --user=system:serviceaccount:kube-system:default
+    kubectl create clusterrolebinding uaaadmin --clusterrole=cluster-admin --user=system:serviceaccount:uaa:default
+    kubectl create clusterrolebinding scfadmin --clusterrole=cluster-admin --user=system:serviceaccount:scf:default
+
+    kubectl apply -f - <<HEREDOC
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: cluster-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-system:default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+HEREDOC
+}
+create_rolebinding

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -41,16 +41,6 @@ terraform apply -auto-approve
 # or:
 terraform output kubeconfig > "$KUBECONFIG"
 
-# make worker nodes join:
-terraform output config_map_aws_auth > eks_cm.yaml
-kubectl apply -f eks_cm.yaml
-
-# wait for workers:
-while kubectl get nodes | grep "notReady" > /dev/null;
-do
-    sleep 10
-done
-
 # test deployment:
 kubectl get svc
 

--- a/backend/eks/deps.sh
+++ b/backend/eks/deps.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+. ../../include/common.sh
+. .envrc
+
+set -u
+
+# pin the kubectl to eks default version
+curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.8/2019-08-14/bin/linux/amd64/kubectl
+chmod +x kubectl && mv kubectl bin/
+
+# pin helm to cap-terraform/eks/modules/eks/<tiller image> version
+curl -o helm.tar.gz https://get.helm.sh/helm-v2.12.3-linux-amd64.tar.gz
+tar -xvf helm.tar.gz
+chmod +x helm && mv helm bin/
+rm -rf helm.tar.gz
+
+mkdir -p .local
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+./awscli-bundle/install --install-dir=$(pwd)/.local/ --bin-location=$(pwd)/bin/aws
+rm -rf awscli-bundle*
+
+curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
+chmod +x aws-iam-authenticator && mv aws-iam-authenticator bin/
+
+curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+# curl -o terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
+unzip terraform.zip
+chmod +x terraform && mv terraform bin/
+rm -rf terraform.zip


### PR DESCRIPTION
This adds EKS deployments with terraform as a possible backend, leveraging github.com/SUSE/cap-terraform.

At the time of writing this, cap-terraform creates a storageclass called gp2, not persistent, so manual work needs to be done to have a working EKS + CAP deployment.