### PR TITLE
Fix builderror in scf build resultet by missing /code voulme

### DIFF
--- a/backend/kind/up.sh
+++ b/backend/kind/up.sh
@@ -17,11 +17,10 @@ kind: $type
 apiVersion: ${KIND_APIVERSION}
 nodes:
 - role: control-plane
-replicas: 1
-extraMounts:
-- containerPath: /code
-  hostPath: ${APPLICATION_PATH}
-  # readOnly: true
+  extraMounts:
+  - containerPath: /code
+    hostPath: ${APPLICATION_PATH}
+    # readOnly: true
 EOF
 
 kind create cluster --config kind-config.yaml --name=${CLUSTER_NAME}

--- a/modules/scf/build.sh
+++ b/modules/scf/build.sh
@@ -17,9 +17,7 @@ pushd scf
     sed -i 's|exit 1||' make/bundle-dist || true
     docker exec "$DOCKER_OPTS" \
     -ti "$CLUSTER_NAME"-control-plane \
-    /bin/bash -c ' apt-get update && apt-get install -y ruby git wget make; '\
-                 ' cd /code/scf && chmod -R 777 src && source .envrc && '\
-                 ' ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
+    /bin/bash -exc ' apt-get update && apt-get install -y ruby git wget make; cd /code/scf && chmod -R 777 src && source .envrc && ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
     cp -rfv output/*.zip ../
 popd
 


### PR DESCRIPTION
Signed-off-by: Ettore Di Glacinto <edigiacinto@suse.com>

This PR fixes the following error when running `make k8s scf-build`:

```
cp: cannot stat 'output/*.zip': No such file or directory                                                                                                                            
make[1]: *** [Makefile:46: build-scf-from-source] Error 1                                                                                                                            
make[1]: Leaving directory 'catapult/modules/scf'                                                                                                 
make: *** [Makefile:146: scf-build] Error 2 
```