### PR TITLE
Add `make stratos-upgrade` redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,10 @@ stratos:
 stratos-clean:
 	make -C modules/stratos clean
 
+.PHONY: stratos-upgrade
+stratos-upgrade:
+	make -C modules/stratos upgrade
+
 # test-only targets:
 .PHONY: tests
 tests:

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,14 @@ stratos:
 stratos-clean:
 	make -C modules/stratos clean
 
+.PHONY: stratos-chart
+stratos-chart:
+	make -C modules/stratos chart
+
+.PHONY: stratos-gen-config
+stratos-gen-config:
+	make -C modules/stratos gen-config
+
 .PHONY: stratos-upgrade
 stratos-upgrade:
 	make -C modules/stratos upgrade

--- a/include/common.sh
+++ b/include/common.sh
@@ -18,7 +18,9 @@ export BUILD_DIR="$ROOT_DIR"/build${CLUSTER_NAME}
 # Forces our build context
 [ -d "$BUILD_DIR" ] && pushd "$BUILD_DIR"
 
-export CHART_URL="${CHART_URL:-}"
+export CHART_URL="${CHART_URL:-}" # FIXME deprecated, used in SCF_CHART
+export SCF_CHART="${SCF_CHART:-$CHART_URL}"
+export STRATOS_CHART="${STRATOS_CHART:-}"
 export SCF_REPO="${SCF_REPO:-https://github.com/SUSE/scf}"
 export SCF_BRANCH="${SCF_BRANCH:-develop}"
 

--- a/modules/scf/Makefile
+++ b/modules/scf/Makefile
@@ -38,7 +38,7 @@ scf-brats-setup:
 	./brats_setup.sh
 
 .PHONY: upgrade
-upgrade: chart gen-config
+upgrade:
 	./upgrade.sh
 
 .PHONY: build-scf-from-source

--- a/modules/scf/Makefile
+++ b/modules/scf/Makefile
@@ -38,7 +38,7 @@ scf-brats-setup:
 	./brats_setup.sh
 
 .PHONY: upgrade
-upgrade:
+upgrade: chart gen-config
 	./upgrade.sh
 
 .PHONY: build-scf-from-source

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -5,23 +5,23 @@ set -e
 
 debug_mode
 
-if [ -z "$CHART_URL" ]; then
+if [ -z "$SCF_CHART" ]; then
     warn "No chart url given - using latest public release from GH"
     if  [ "${SCF_OPERATOR}" != "true" ]; then
-        CHART_URL=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
+        SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
     else
-        CHART_URL="https://scf-v3.s3.amazonaws.com/scf-3.0.0-8f7a71d1.tgz"
-        #CHART_URL="https://github.com/SUSE/scf/archive/v3-develop.zip"
+        SCF_CHART="https://scf-v3.s3.amazonaws.com/scf-3.0.0-8f7a71d1.tgz"
+        #SCF_CHART="https://github.com/SUSE/scf/archive/v3-develop.zip"
     fi
 fi
 
-if echo "$CHART_URL" | grep -q "http"; then
-    wget "$CHART_URL" -O chart
+if echo "$SCF_CHART" | grep -q "http"; then
+    wget "$SCF_CHART" -O chart
 else
-    cp -rfv "$CHART_URL" chart
+    cp -rfv "$SCF_CHART" chart
 fi
 
-if echo "$CHART_URL" | grep -q "tgz"; then
+if echo "$SCF_CHART" | grep -q "tgz"; then
     tar -xvf chart -C ./
 else
     unzip -o chart

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -34,7 +34,7 @@ fi
 
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf
 
-# delete CHART_URL on cap-values configmap
+# delete SCF_CHART on cap-values configmap
 kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "null"'
 
 ok "Cleaned up scf from the k8s cluster"

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -32,7 +32,7 @@ if [[ "$ENABLE_EIRINI" == true ]] ; then
     fi
 fi
 
-rm -rf scf-config-values.yaml chart.zip helm kube "$CF_HOME"/.cf
+rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf
 
 # delete CHART_URL on cap-values configmap
 kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "null"'

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -7,8 +7,8 @@ set -e
 
 debug_mode
 
-# save CHART_URL on cap-values configmap
-kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$CHART_URL'"'
+# save SCF_CHART on cap-values configmap
+kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'
 
 if [[ $ENABLE_EIRINI == true ]] ; then
     [ ! -f "helm/cf/templates/eirini-namespace.yaml" ] && kubectl create namespace eirini

--- a/modules/scf/upgrade.sh
+++ b/modules/scf/upgrade.sh
@@ -7,9 +7,9 @@ set -e
 
 debug_mode
 
-if [ -n "$CHART_URL" ]; then
-# save CHART_URL on cap-values configmap
-    kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$CHART_URL'"'
+if [ -n "$SCF_CHART" ]; then
+# save SCF_CHART on cap-values configmap
+    kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART"'
 fi
 
 SECRET=$(kubectl get pods --namespace uaa \

--- a/modules/stratos/Makefile
+++ b/modules/stratos/Makefile
@@ -17,7 +17,7 @@ install:
 	./install.sh
 
 .PHONY: upgrade
-upgrade: chart gen-config
+upgrade:
 	./upgrade.sh
 
 .PHONY: all

--- a/modules/stratos/Makefile
+++ b/modules/stratos/Makefile
@@ -1,9 +1,24 @@
-.DEFAULT_GOAL := install
+.DEFAULT_GOAL := all
 
 .PHONY: clean
 clean:
 	./clean.sh
 
+.PHONY: chart
+chart:
+	./chart.sh
+
+.PHONY: gen-config
+gen-config:
+	./gen-config.sh
+
 .PHONY: install
 install:
 	./install.sh
+
+.PHONY: upgrade
+upgrade: chart gen-config
+	./upgrade.sh
+
+.PHONY: all
+all: clean chart gen-config install

--- a/modules/stratos/chart.sh
+++ b/modules/stratos/chart.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+. ../../include/common.sh
+. .envrc
+
+set -Eexuo pipefail
+debug_mode
+
+if [ -z "$STRATOS_CHART" ]; then
+    warn "No chart url given - using latest public release from GH"
+        STRATOS_CHART=$(curl -s https://api.github.com/repos/cloudfoundry/stratos/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
+fi
+
+if echo "$STRATOS_CHART" | grep -q "http"; then
+    curl -L "$STRATOS_CHART" -o stratos-chart
+else
+    cp -rfv "$STRATOS_CHART" stratos-chart
+fi
+
+# remove old uncompressed chart
+rm -rf console
+
+if echo "$STRATOS_CHART" | grep -q "tgz"; then
+    tar -xvf stratos-chart -C ./
+else
+    unzip -o stratos-chart
+fi
+rm stratos-chart
+
+ok "Chart uncompressed"

--- a/modules/stratos/clean.sh
+++ b/modules/stratos/clean.sh
@@ -3,7 +3,7 @@
 . ../../include/common.sh
 . .envrc
 
-set -exuo pipefail
+set -Eexuo pipefail
 
 if helm ls 2>/dev/null | grep -qi susecf-console ; then
     helm del --purge susecf-console
@@ -11,3 +11,8 @@ fi
 if kubectl get namespaces 2>/dev/null | grep -qi stratos ; then
     kubectl delete namespace stratos
 fi
+
+# delete STRATOS_CHART on cap-values configmap
+kubectl patch -n kube-system configmap cap-values -p $'data:\n stratos-chart: "null"'
+
+rm -rf console scf-config-values-for-stratos.yaml

--- a/modules/stratos/gen-config.sh
+++ b/modules/stratos/gen-config.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+. ../../include/common.sh
+. .envrc
+
+set -Eexuo pipefail
+debug_mode
+
+info "Generating stratos config values from scf values"
+
+cp scf-config-values.yaml scf-config-values-for-stratos.yaml
+
+cat <<HEREDOC_APPEND >> scf-config-values-for-stratos.yaml
+
+# Appended for stratos:
+
+kube:
+  registry:
+    hostname: "${DOCKER_REGISTRY}"
+    username: "${DOCKER_USERNAME}"
+    password: "${DOCKER_PASSWORD}"
+HEREDOC_APPEND
+
+ok "Stratos config values generated"

--- a/modules/stratos/install.sh
+++ b/modules/stratos/install.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-set -ex
+set -Eexuo pipefail
 
 . ../../include/common.sh
 . .envrc
 
-helm repo add suse https://kubernetes-charts.suse.com/
+# save STRATOS_CHART on cap-values configmap
+kubectl patch -n kube-system configmap cap-values -p $'data:\n stratos-chart: "'$STRATOS_CHART'"'
 
-helm install suse/console \
+helm install ./console \
     --name susecf-console \
     --namespace stratos \
-    --values scf-config-values.yaml
+    --values scf-config-values-for-stratos.yaml
 
 bash "$ROOT_DIR"/include/wait_ns.sh stratos
+
+helm status susecf-console | grep ui-ext
+
+ok "Stratos deployed successfully"

--- a/modules/stratos/upgrade.sh
+++ b/modules/stratos/upgrade.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+. ../../include/common.sh
+. .envrc
+
+debug_mode
+
+if [ -n "$STRATOS_CHART" ]; then
+    # save STRATOS_CHART on cap-values configmap
+    kubectl patch -n kube-system configmap cap-values -p $'data:\n stratos-chart: "'$STRATOS_CHART'"'
+fi
+
+helm upgrade susecf-console ./console \
+     --recreate-pods \
+     --values scf-config-values.yaml
+
+bash "$ROOT_DIR"/include/wait_ns.sh stratos
+
+ok "Stratos deployment upgraded successfully"


### PR DESCRIPTION
This PR adds a public make stratos-upgrade. Also:
- Pass stratos chart on STRATOS_CHART
- Deprecate CHART_URL, add SCF_CHART that takes the previous.
- Add private make -C modules/stratos chart to put the chart on buildir/console
- Add private make -C modules/stratos gen-config to copy the scf-config-values.yaml to scf-config-values-for-stratos.yaml, where one can point to a different registry.
