### PR TITLE
Add json config and helm repo fetch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-export BACKEND?=kind
+
+# NOTE: BACKEND is dup in include/common.sh to allow BACKEND override when loading from json config files
+BACKEND?=kind
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .DEFAULT_GOAL := all

--- a/backend/kind/deps.sh
+++ b/backend/kind/deps.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-# duplicated in s/include/common.sh, needed for bootstrapping:
-export CLUSTER_NAME=${CLUSTER_NAME:-kind}
-export BUILD_DIR=build${CLUSTER_NAME}
-
 . ../../include/common.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/include/buildir.sh
+++ b/include/buildir.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # duplicated in s/include/common.sh, needed for bootstrapping:
-. include/common.sh
+. $ROOT_DIR/include/common.sh
 
 info "Creating $BUILD_DIR"
 mkdir "$BUILD_DIR"
-. include/common.sh # Reload, as we just created BUILD_DIR
+. $ROOT_DIR/include/common.sh # Reload, as we just created BUILD_DIR
 
 mkdir bin
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -5,6 +5,10 @@ source $ROOT_DIR/include/func.sh
 
 debug_mode
 
+if [ -n "$CONFIG" ]; then
+  load_env_from_json "$CONFIG"
+fi
+
 export VALUES_OVERRIDE="${VALUES_OVERRIDE:-}"
 OVERRIDE=
 if [ -n "$VALUES_OVERRIDE" ] && [ -f "$VALUES_OVERRIDE" ]; then

--- a/include/common.sh
+++ b/include/common.sh
@@ -9,6 +9,7 @@ if [ -n "$CONFIG" ]; then
   load_env_from_json "$CONFIG"
 fi
 
+export BACKEND="${BACKEND:-kind}"
 export VALUES_OVERRIDE="${VALUES_OVERRIDE:-}"
 OVERRIDE=
 if [ -n "$VALUES_OVERRIDE" ] && [ -f "$VALUES_OVERRIDE" ]; then

--- a/include/func.sh
+++ b/include/func.sh
@@ -156,7 +156,8 @@ function debug_mode {
 }
 
 function load_env_from_json {
-    eval "$(jq -r ' to_entries | .[] | "export "+ .key + "=\"" + .value + "\""' < $1)"
+    # Export but preserve one that are passed explictly
+    eval "$(jq -r ' to_entries | .[] | "export "+ .key + "=\"${"+ .key + ":-" + .value + "}\""' < $1)"
 }
 
 debug_mode

--- a/include/func.sh
+++ b/include/func.sh
@@ -155,4 +155,8 @@ function debug_mode {
     fi
 }
 
+function load_env_from_json {
+    eval "$(jq -r ' to_entries | .[] | "export "+ .key + "=\"" + .value + "\""' < $1)"
+}
+
 debug_mode

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -63,11 +63,11 @@ if [ -n "$SCF_HELM_VERSION" ]; then
     popd
 fi
 
-rm -rf chart_url || true
+rm -rf scf_chart_url || true
 
 if echo "$SCF_CHART" | grep -q "http"; then
     wget "$SCF_CHART" -O chart
-    echo "$SCF_CHART" > chart_url
+    echo "$SCF_CHART" > scf_chart_url
 else
     cp -rfv "$SCF_CHART" chart
 fi

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -63,9 +63,11 @@ if [ -n "$SCF_HELM_VERSION" ]; then
     popd
 fi
 
+rm -rf chart_url || true
+
 if echo "$SCF_CHART" | grep -q "http"; then
-    info "Downloading $SCF_CHART"
     wget "$SCF_CHART" -O chart
+    echo "$SCF_CHART" > chart_url
 else
     cp -rfv "$SCF_CHART" chart
 fi
@@ -80,4 +82,4 @@ if  [ "${SCF_OPERATOR}" == "true" ]; then
     cp -rfv scf*/* ./
 fi
 
-ok "Chart uncompressed from $SCF_CHART"
+ok "Chart uncompressed"

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -5,7 +5,7 @@ set -e
 
 debug_mode
 
-if [ -z "$SCF_CHART" ]; then
+if [ -z "$SCF_CHART" ] && [ -z "$SCF_HELM_VERSION" ]; then
     warn "No chart url given - using latest public release from GH"
     if  [ "${SCF_OPERATOR}" != "true" ]; then
         SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
@@ -15,7 +15,56 @@ if [ -z "$SCF_CHART" ]; then
     fi
 fi
 
+if [ -n "$SCF_HELM_VERSION" ]; then
+    HELM_VERSION="$SCF_HELM_VERSION"
+    HELM_REPO="${SCF_HELM_REPO:-https://kubernetes-charts.suse.com/}"
+    HELM_REPO_NAME="${SCF_HELM_REPO_NAME:-suse}"
+    info "Grabbing $SCF_HELM_VERSION from $HELM_REPO"
+
+    helm init --client-only
+    helm repo add "$HELM_REPO_NAME" $HELM_REPO
+    helm repo update
+
+    if [ -n "$HELM_VERSION" ]; then
+
+        helm fetch "$HELM_REPO_NAME"/cf --version $HELM_VERSION
+        helm fetch "$HELM_REPO_NAME"/uaa --version $HELM_VERSION
+
+    else
+
+        helm fetch "$HELM_REPO_NAME"/cf
+        helm fetch "$HELM_REPO_NAME"/uaa
+
+    fi
+
+    # FIXME: Platform hardcoded for now - should we have a global deps step?
+    [ ! -e "bin/yq" ] && wget https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -O bin/yq && chmod +x bin/yq
+
+    mkdir -p charts/helm
+    tar xvf cf-*.tgz -C charts/helm
+    tar xvf uaa-*.tgz -C charts/helm
+    pushd charts
+        VERSION=$(../bin/yq r helm/cf/Chart.yaml version)
+        API_VERSION=$(../bin/yq r helm/cf/Chart.yaml apiVersion)
+
+        if [ -z "$VERSION" ]; then
+            err "No version found from the chart"
+            exit 1
+        fi
+
+        if [ -z "$API_VERSION" ]; then
+            err "No api version found from the chart"
+            exit 1
+        fi
+        info "Producing bundle for $API_VERSION - $VERSION"
+        tar cvzf ../scf-sle-${API_VERSION}.tgz *
+        zip -r9 ../scf-sle-${API_VERSION}.zip -- *
+        export SCF_CHART=$PWD/../scf-sle-${API_VERSION}.zip
+    popd
+fi
+
 if echo "$SCF_CHART" | grep -q "http"; then
+    info "Downloading $SCF_CHART"
     wget "$SCF_CHART" -O chart
 else
     cp -rfv "$SCF_CHART" chart
@@ -31,4 +80,4 @@ if  [ "${SCF_OPERATOR}" == "true" ]; then
     cp -rfv scf*/* ./
 fi
 
-ok "Chart uncompressed"
+ok "Chart uncompressed from $SCF_CHART"

--- a/tests/tests_catapult.sh
+++ b/tests/tests_catapult.sh
@@ -73,5 +73,36 @@ testBackendImported() {
     assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
 }
 
+# Tests Json config switch
+testJson() {
+  unset CLUSTER_NAME
+  unset BACKEND
+  rm -rf buildjson
+  echo '{ "BACKEND": "gke", "CLUSTER_NAME": "json" }' > test.json
+  CONFIG=$PWD/test.json make buildir
+  assertTrue 'create buildir' "[ -d 'buildjson' ]"
+  ENVRC="$(cat "$PWD"/buildjson/.envrc)"
+  assertContains 'contains BACKEND' "$ENVRC" 'BACKEND=gke'
+  assertContains 'contains CLUSTER_NAME' "$ENVRC" 'CLUSTER_NAME=json'
+  CONFIG=$PWD/test.json make clean
+  assertTrue 'clean buildir' "[ ! -d 'buildjson' ]"
+  rm -rf test.json
+}
+
+testJsonOverrides() {
+  unset CLUSTER_NAME
+  unset BACKEND
+  rm -rf buildjson
+  echo '{ "BACKEND": "gke", "CLUSTER_NAME": "json" }' > test.json
+  BACKEND=imported CONFIG=$PWD/test.json make buildir
+  assertTrue 'create buildir' "[ -d 'buildjson' ]"
+  ENVRC="$(cat "$PWD"/buildjson/.envrc)"
+  assertContains 'contains BACKEND' "$ENVRC" 'BACKEND=imported'
+  assertContains 'contains CLUSTER_NAME' "$ENVRC" 'CLUSTER_NAME=json'
+  BACKEND=imported CONFIG=$PWD/test.json make clean
+  assertTrue 'clean buildir' "[ ! -d 'buildjson' ]"
+  rm -rf test.json
+}
+
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/tests_catapult.sh
+++ b/tests/tests_catapult.sh
@@ -110,14 +110,14 @@ testscfChart() {
   assertTrue 'yq was not downloaded' "[ ! -e 'buildtest/bin/yq' ]"
   assertTrue 'chart downloaded from URL (chart is present)' "[ -e 'buildtest/chart' ]"
   assertTrue 'chart was not generated' '[ -z "$(ls buildtest/*.tgz buildtest/*.zip)" ]'
-  assertTrue 'chart downloaded (chart_url is present)' "[ -e 'buildtest/chart_url' ]"
-  assertTrue 'chart downloaded from an http resource (chart_url contains http)' "grep 'http' 'buildtest/chart_url'"
+  assertTrue 'chart downloaded (scf_chart_url is present)' "[ -e 'buildtest/scf_chart_url' ]"
+  assertTrue 'chart downloaded from an http resource (scf_chart_url contains http)' "grep 'http' 'buildtest/scf_chart_url'"
 
   SCF_HELM_VERSION="2.14.5" DEFAULT_STACK=sle15 CLUSTER_PASSWORD=test123 make buildir scf-chart scf-gen-config
   assertTrue 'yq was downloaded' "[ -e 'buildtest/bin/yq' ]"
   assertTrue 'chart was generated (tgz present)' "[ -e 'buildtest/scf-sle-2.14.5+cf2.7.0.0.g6360c016.tgz' ]"
   assertTrue 'chart was generated (zip present)' "[ -e 'buildtest/scf-sle-2.14.5+cf2.7.0.0.g6360c016.zip' ]"
-  assertTrue 'chart not downloaded' "[ ! -e 'buildtest/chart_url' ]"
+  assertTrue 'chart not downloaded' "[ ! -e 'buildtest/scf_chart_url' ]"
 
   make clean
   assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
@@ -126,9 +126,9 @@ testscfChart() {
   assertTrue 'yq was not downloaded' "[ ! -e 'buildtest/bin/yq' ]"
   assertTrue 'chart downloaded from URL (chart is present)' "[ -e 'buildtest/chart' ]"
   assertTrue 'chart was not generated' '[ -z "$(ls buildtest/*.tgz buildtest/*.zip)" ]'
-  assertTrue 'chart downloaded (chart_url is present)' "[ -e 'buildtest/chart_url' ]"
-  assertTrue 'chart downloaded from an http resource (chart_url contains http)' "grep 'http' 'buildtest/chart_url'"
-  assertTrue 'chart downloaded from an http resource matches' '[[ "https://github.com/SUSE/scf/releases/download/2.16.4/scf-sle-2.16.4+cf6.10.0.2.g5abdb16f.zip" == "$(cat buildtest/chart_url)" ]]'
+  assertTrue 'chart downloaded (scf_chart_url is present)' "[ -e 'buildtest/scf_chart_url' ]"
+  assertTrue 'chart downloaded from an http resource (scf_chart_url contains http)' "grep 'http' 'buildtest/scf_chart_url'"
+  assertTrue 'chart downloaded from an http resource matches' '[[ "https://github.com/SUSE/scf/releases/download/2.16.4/scf-sle-2.16.4+cf6.10.0.2.g5abdb16f.zip" == "$(cat buildtest/scf_chart_url)" ]]'
 
   make clean
   assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"

--- a/tests/tests_catapult.sh
+++ b/tests/tests_catapult.sh
@@ -104,5 +104,24 @@ testJsonOverrides() {
   rm -rf test.json
 }
 
+testscfChart() {
+  rm -rf buildtest
+  DEFAULT_STACK=sle15 CLUSTER_PASSWORD=test123 make buildir scf-chart scf-gen-config
+  assertTrue 'yq was not downloaded' "[ ! -e 'buildtest/bin/yq' ]"
+  assertTrue 'chart downloaded from URL (chart is present)' "[ -e 'buildtest/chart' ]"
+  assertTrue 'chart was not generated' '[ -z "$(ls buildtest/*.tgz buildtest/*.zip)" ]'
+  assertTrue 'chart downloaded (chart_url is present)' "[ -e 'buildtest/chart_url' ]"
+  assertTrue 'chart downloaded from an http resource (chart_url contains http)' "grep 'http' 'buildtest/chart_url'"
+
+  SCF_HELM_VERSION="2.14.5" DEFAULT_STACK=sle15 CLUSTER_PASSWORD=test123 make buildir scf-chart scf-gen-config
+  assertTrue 'yq was downloaded' "[ -e 'buildtest/bin/yq' ]"
+  assertTrue 'chart was generated (tgz present)' "[ -e 'buildtest/scf-sle-2.14.5+cf2.7.0.0.g6360c016.tgz' ]"
+  assertTrue 'chart was generated (zip present)' "[ -e 'buildtest/scf-sle-2.14.5+cf2.7.0.0.g6360c016.zip' ]"
+  assertTrue 'chart not downloaded' "[ ! -e 'buildtest/chart_url' ]"
+
+  make clean
+  assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
+}
+
 # Load shUnit2.
 . ./shunit2/shunit2

--- a/tests/tests_catapult.sh
+++ b/tests/tests_catapult.sh
@@ -121,6 +121,17 @@ testscfChart() {
 
   make clean
   assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
+
+  SCF_CHART="https://github.com/SUSE/scf/releases/download/2.16.4/scf-sle-2.16.4+cf6.10.0.2.g5abdb16f.zip" DEFAULT_STACK=sle15 CLUSTER_PASSWORD=test123 make buildir scf-chart scf-gen-config
+  assertTrue 'yq was not downloaded' "[ ! -e 'buildtest/bin/yq' ]"
+  assertTrue 'chart downloaded from URL (chart is present)' "[ -e 'buildtest/chart' ]"
+  assertTrue 'chart was not generated' '[ -z "$(ls buildtest/*.tgz buildtest/*.zip)" ]'
+  assertTrue 'chart downloaded (chart_url is present)' "[ -e 'buildtest/chart_url' ]"
+  assertTrue 'chart downloaded from an http resource (chart_url contains http)' "grep 'http' 'buildtest/chart_url'"
+  assertTrue 'chart downloaded from an http resource matches' '[[ "https://github.com/SUSE/scf/releases/download/2.16.4/scf-sle-2.16.4+cf6.10.0.2.g5abdb16f.zip" == "$(cat buildtest/chart_url)" ]]'
+
+  make clean
+  assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
 }
 
 # Load shUnit2.


### PR DESCRIPTION
It adds support to config files and allows to directly fetch and re-assemble charts from the official helm repo.

Note: the `BACKEND` cannot yet be annotated in the json as it is needed in the Makefile and it will be ignored. And ENV vars have precedence over the one specified in the json (done on purpose!).

Json config:
`CONFIG=/path/to/json BACKEND=backend make [..]`

Use chart from helm (need to pass the SCF version):
`SCF_HELM_VERSION=2.14.5 make [..]`

e.g.:
```
$> cat support.json
{
  "SCF_HELM_VERSION": "2.14.5",
  "CLUSTER_NAME": "support",
  "ENABLE_EIRINI": "false",
  "EKCP_HOST": "....
}
```