### PR TITLE
Cleanly remove data from cap-values

### DIFF
--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -35,6 +35,8 @@ fi
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
 
 # delete SCF_CHART on cap-values configmap
-kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "null"'
+if [[ -n "$(kubectl get -n kube-system configmap cap-values | jq -r '.data.chart')" ]]; then
+    kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/chart"}]'
+fi
 
 ok "Cleaned up scf from the k8s cluster"

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -35,7 +35,7 @@ fi
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
 
 # delete SCF_CHART on cap-values configmap
-if [[ -n "$(kubectl get -n kube-system configmap cap-values | jq -r '.data.chart')" ]]; then
+if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.chart // empty')" ]]; then
     kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/chart"}]'
 fi
 

--- a/modules/stratos/clean.sh
+++ b/modules/stratos/clean.sh
@@ -13,6 +13,9 @@ if kubectl get namespaces 2>/dev/null | grep -qi stratos ; then
 fi
 
 # delete STRATOS_CHART on cap-values configmap
+if [[ -n "$(kubectl get -n kube-system configmap cap-values | jq -r '.data["stratos-chart"]')" ]]; then
+    kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/stratos-chart"}]'
+fi
 kubectl patch -n kube-system configmap cap-values -p $'data:\n stratos-chart: "null"'
 
 rm -rf console scf-config-values-for-stratos.yaml

--- a/modules/stratos/clean.sh
+++ b/modules/stratos/clean.sh
@@ -13,9 +13,8 @@ if kubectl get namespaces 2>/dev/null | grep -qi stratos ; then
 fi
 
 # delete STRATOS_CHART on cap-values configmap
-if [[ -n "$(kubectl get -n kube-system configmap cap-values | jq -r '.data["stratos-chart"]')" ]]; then
+if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data["stratos-chart"] // empty')" ]]; then
     kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/stratos-chart"}]'
 fi
-kubectl patch -n kube-system configmap cap-values -p $'data:\n stratos-chart: "null"'
 
 rm -rf console scf-config-values-for-stratos.yaml


### PR DESCRIPTION
- Deleting keys outright rather than setting them to the string "null"
restores the cap-values state to a pre-install state
- In the event that clean steps are run twice, attempting to use patch
to set a key to its current value will result in a failure, as the
patch command is surpsisingly *not* idempotent