### PR TITLE
Add STORAGECLASS option on scf-gen-config target

### DIFF
--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -18,6 +18,7 @@ else
 fi
 
 DIEGO_SIZING="${DIEGO_SIZING:-$SIZING}"
+STORAGECLASS="${STORAGECLASS:-persistent}"
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
@@ -79,7 +80,7 @@ env:
         name: "default"
         description: "Eirini persistence broker"
         free: true
-        kube_storage_class: "persistent"
+        kube_storage_class: "${STORAGECLASS}"
         default_size: "2Gi"
 
   # UAA host and port
@@ -173,8 +174,8 @@ kube:
   # Run kubectl get storageclasses
   # to view your available storage classes
   storage_class:
-    persistent: "persistent"
-    shared: "shared"
+    persistent: "${STORAGECLASS}"
+    shared: "${STORAGECLASS}"
 
   # The registry the images will be fetched from.
   # The values below should work for

--- a/tests/tests_catapult.sh
+++ b/tests/tests_catapult.sh
@@ -34,7 +34,7 @@ testBuilddir() {
 testConfig() {
   rm -rf buildtest
   make buildir
-  DEFAULT_STACK=sle CLUSTER_PASSWORD=test123 make scf-gen-config
+  DEFAULT_STACK=sle CLUSTER_PASSWORD=test123 STORAGECLASS=our-storage make scf-gen-config
   assertTrue 'create buildir' "[ -d $ROOT_DIR/buildtest ]"
   assertTrue 'create config values' "[ -e $ROOT_DIR/buildtest/scf-config-values.yaml ]"
 
@@ -43,6 +43,9 @@ testConfig() {
   assertContains 'generates correctly KUBE_CSR_AUTO_APPROVAL' "$VALUES_FILE" "KUBE_CSR_AUTO_APPROVAL: true"
   assertContains 'generates correctly DEFAULT_STACK' "$VALUES_FILE" "DEFAULT_STACK: \"sle\""
   assertContains 'generates correctly GARDEN_ROOTFS_DRIVER' "$VALUES_FILE" "GARDEN_ROOTFS_DRIVER: \"btrfs\""
+  assertContains 'generates correctly STORAGECLASS (1)' "$VALUES_FILE" "kube_storage_class: \"our-storage\""
+  assertContains 'generates correctly STORAGECLASS (2)' "$VALUES_FILE" "persistent: \"our-storage\""
+  assertContains 'generates correctly STORAGECLASS (3)' "$VALUES_FILE" "shared: \"our-storage\""
 }
 
 # Tests backend switch


### PR DESCRIPTION
Allows to select which storageclass are we going to use in scf-config-values.yaml