### PR TITLE
Raise master nodes to 3 by default

### DIFF
--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -33,7 +33,7 @@ stack_name = "#~placeholder_stack~#"
 subnet_cidr = "172.28.0.0/24"
 
 # Number of master nodes
-masters = 1
+masters = 3
 
 # Number of worker nodes
 workers = 3


### PR DESCRIPTION
We want to deploy multi-master on ECP to have a more realistic test
environment.