### PR TITLE
Add make scf-install as public target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ scf-login:
 scf-gen-config:
 	$(MAKE) -C modules/scf gen-config
 
+.PHONY: scf-install
+scf-install:
+	$(MAKE) -C modules/scf install
+
 .PHONY: scf-upgrade
 scf-upgrade:
 	$(MAKE) -C modules/scf upgrade


### PR DESCRIPTION
No need to do `make private modules/scf install`, we can do `make scf-install`.

I'm a convert.