### PR TITLE
Fix and default to CAASP_VER=update in BACKEND=caasp4os

### DIFF
--- a/backend/caasp4os/defaults.sh
+++ b/backend/caasp4os/defaults.sh
@@ -3,5 +3,5 @@
 # Caasp4os options
 ##################
 
-CAASP_VER=${CAASP_VER:-"product"}
+CAASP_VER=${CAASP_VER:-"update"} # devel, staging, update, product
 STACK=${STACK:-"$(whoami)-caasp4-${CAASP_VER::3}-$CLUSTER_NAME"}

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -13,7 +13,7 @@
 . .envrc
 
 # nip.io doesn't seem to work well with ECP, use omg.h.w instead:
-export MAGICDNS=${MAGICDNS:-'omg.howdoi.website'}
+export MAGICDNS=omg.howdoi.website
 
 
 if [[ ! -v OS_PASSWORD ]]; then

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -70,8 +70,6 @@ sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
     -e "s%#~placeholder_sshkey~#%$(escapeSubst "$SSHKEY")%g" \
     "$ROOT_DIR"/backend/caasp4os/terraform-os/terraform.tfvars.skel > \
     deployment/terraform.tfvars
-sed -i '/\"\${openstack_networking_secgroup_v2\.common\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' \
-    deployment/worker-instance.tf
 cp -r "$ROOT_DIR"/backend/caasp4os/terraform-os/* deployment/
 
 pushd deployment

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -81,24 +81,6 @@ skuba_container terraform init
 skuba_container terraform plan -out my-plan
 skuba_container terraform apply -auto-approve my-plan
 
-# Install caasp product on all nodes
-skuba_run_cmd all "sudo zypper in -y -l --auto-agree-with-product-licenses -t product caasp"
-wait
-# Update all nodes
-skuba_run_cmd all "sudo zypper ref && sudo zypper up -y -l --auto-agree-with-product-licenses"
-wait
-skuba_run_cmd all "sudo zypper in -y -t pattern SUSE-CaaSP-Node"
-wait
-# Enable swapaccount on all k8s nodes
-skuba_run_cmd all "sudo sed -i -r 's|^(GRUB_CMDLINE_LINUX_DEFAULT=)\"(.*.)\"|\1\"\2 cgroup_enable=memory swapaccount=1 \"|' /etc/default/grub"
-wait
-skuba_run_cmd all 'sudo grub2-mkconfig -o /boot/grub2/grub.cfg'
-wait
-skuba_run_cmd all 'sleep 2 && sudo nohup shutdown -r now > /dev/null 2>&1 &'
-wait
-# skuba_wait_ssh all 100
-sleep 100
-
 # Bootstrap k8s with skuba
 skuba_container skuba version
 skuba_deploy

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -50,10 +50,11 @@ case "$CAASP_VER" in
          CAASP_REPO='caasp_40_staging_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/"'
          ;;
     "product")
-         CAASP_REPO='caasp_40_product_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/"'
+         # Already on terraform.tfvars
+         CAASP_REPO=
          ;;
     "update")
-         CAASP_REPO='caasp_40_update_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/"'
+         CAASP_REPO='caasp_40_update_sle15sp1 = "http://download.suse.de/ibs/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/"',
          ;;
 esac
 escapeSubst() {

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -64,12 +64,10 @@ escapeSubst() {
 }
 # save only first ssh key, caasp4 terraform script constraints:
 SSHKEY="$(ssh-add -L | head -n 1)"
-CAASP_PATTERN='patterns-caasp-Node-1.15'
 sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
     -e "s%#~placeholder_magic_dns~#%$(escapeSubst "$MAGICDNS")%g" \
     -e "s%#~placeholder_caasp_repo~#%$(escapeSubst "$CAASP_REPO")%g" \
     -e "s%#~placeholder_sshkey~#%$(escapeSubst "$SSHKEY")%g" \
-    -e "s%#~placeholder_caasp_pattern~#%$(escapeSubst "$CAASP_PATTERN")%g" \
     "$ROOT_DIR"/backend/caasp4os/terraform-os/terraform.tfvars.skel > \
     deployment/terraform.tfvars
 sed -i '/\"\${openstack_networking_secgroup_v2\.common\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' \

--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -4,12 +4,27 @@ ARG VERSION
 ARG REPO_ENV
 ARG REPO
 
-RUN zypper ar --no-gpgcheck "${REPO}" "skuba-${REPO_ENV}" && \
-    zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/" caasp-product && \
-    zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo" && \
-    zypper ref && \
-    zypper in --auto-agree-with-licenses --no-confirm "skuba-${VERSION}" terraform ca-certificates-suse openssh && \
-    zypper clean -a
+ARG IBS="http://download.suse.de/ibs/SUSE"
+RUN for repo in SLE-Product-SLES SLE-Module-Basesystem SLE-Module-Containers; do \
+    zypper ar $IBS/Products/$repo/15-SP1/x86_64/product ${repo}_pool; \
+    zypper ar $IBS/Updates/$repo/15-SP1/x86_64/update ${repo}_updates; \
+done
+RUN zypper ar $IBS/Products/SUSE-CAASP/4.0/x86_64/product CAASP_pool
+# RUN zypper ar $IBS/Updates/SUSE-CAASP/4.0/x86_64/update CAASP_updates
+RUN zypper ar --no-gpgcheck "${REPO}" "skuba-${REPO_ENV}"
+
+RUN zypper refresh; zypper -n dist-upgrade
+RUN zypper --gpg-auto-import-keys ref -s
+
+
+# RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/" caasp-product
+RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo"
+# RUN zypper ref
+RUN zypper in --auto-agree-with-licenses --no-confirm -t product caasp
+RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse
+RUN zypper -n in -t pattern SUSE-CaaSP-Management
+RUN zypper up
+RUN zypper clean -a
 
 VOLUME ["/app"]
 

--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -21,7 +21,7 @@ RUN zypper --gpg-auto-import-keys ref -s
 RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo"
 # RUN zypper ref
 RUN zypper in --auto-agree-with-licenses --no-confirm -t product caasp
-RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse
+RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse openssh
 RUN zypper -n in -t pattern SUSE-CaaSP-Management
 RUN zypper up
 RUN zypper clean -a

--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -5,6 +5,7 @@ ARG REPO_ENV
 ARG REPO
 
 RUN zypper ar --no-gpgcheck "${REPO}" "skuba-${REPO_ENV}" && \
+    zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/" caasp-product && \
     zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo" && \
     zypper ref && \
     zypper in --auto-agree-with-licenses --no-confirm "skuba-${VERSION}" terraform ca-certificates-suse openssh && \

--- a/backend/caasp4os/docker/skuba/Makefile
+++ b/backend/caasp4os/docker/skuba/Makefile
@@ -1,3 +1,4 @@
+.PHONY: devel
 devel:
 	./build.sh devel http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/
 
@@ -5,8 +6,10 @@ devel:
 staging:
 	./build.sh staging http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/
 
+.PHONY: product
 product:
-	./build.sh product http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
+	./build.sh product http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/
 
+.PHONY: update
 update:
-	./build.sh update http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/
+	./build.sh update http://download.suse.de/ibs/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/

--- a/backend/caasp4os/docker/skuba/build.sh
+++ b/backend/caasp4os/docker/skuba/build.sh
@@ -5,7 +5,7 @@ REPO="$2"
 VERSION=
 
 retrieve_version() {
-  local output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
+  local output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/ caasp4-product && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
 
   if [[ $? -eq 0 ]]; then
     # 0.5.0-1.2 ^M$

--- a/backend/caasp4os/terraform-os/cloud-init/common.tpl
+++ b/backend/caasp4os/terraform-os/cloud-init/common.tpl
@@ -1,0 +1,55 @@
+#cloud-config
+
+# set locale
+locale: en_US.UTF-8
+
+# set timezone
+timezone: Etc/UTC
+
+# Inject the public keys
+ssh_authorized_keys:
+${authorized_keys}
+
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
+# need to disable gpg checks because the cloud image has an untrusted repo
+zypper:
+  repos:
+${repositories}
+  config:
+    gpgcheck: "off"
+    solver.onlyRequires: "true"
+    download.use_deltarpm: "true"
+
+# need to remove the standard docker packages that are pre-installed on the
+# cloud image because they conflict with the kubic- ones that are pulled by
+# the kubernetes packages
+# WARNING!!! Do not use cloud-init packages module when SUSE CaaSP Registraion
+# Code is provided. In this case repositories will be added in runcmd module
+# with SUSEConnect command after packages module is ran
+#packages:
+
+bootcmd:
+  - ip link set dev eth0 mtu 1400
+
+runcmd:
+  # workaround for bsc#1119397 . If this is not called, /etc/resolv.conf is empty
+  - netconfig -f update
+  # Workaround for bsc#1138557 . Disable root and password SSH login
+  - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i -e '/^#ChallengeResponseAuthentication/s/^.*$/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+  - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - sshd -t || echo "ssh syntax failure"
+  - systemctl restart sshd
+${register_scc}
+${register_rmt}
+${register_ibs}
+${commands}
+
+final_message: "The system is finally up, after $UPTIME seconds"

--- a/backend/caasp4os/terraform-os/cloud-init/register-ibs.tpl
+++ b/backend/caasp4os/terraform-os/cloud-init/register-ibs.tpl
@@ -1,4 +1,4 @@
   - /usr/sbin/update-ca-certificates &> /dev/null
-  - zypper in -y -l --auto-agree-with-product-licenses caasp-release caasp &> /dev/null
+  - zypper in -y -l --auto-agree-with-product-licenses -t product caasp
   - zypper in -y -l -t pattern SUSE-CaaSP-Node &> /dev/null
   - zypper up -y -l --auto-agree-with-product-licenses 2>&1>/dev/null

--- a/backend/caasp4os/terraform-os/cloud-init/register-ibs.tpl
+++ b/backend/caasp4os/terraform-os/cloud-init/register-ibs.tpl
@@ -1,0 +1,4 @@
+  - /usr/sbin/update-ca-certificates &> /dev/null
+  - zypper in -y -l --auto-agree-with-product-licenses caasp-release caasp &> /dev/null
+  - zypper in -y -l -t pattern SUSE-CaaSP-Node &> /dev/null
+  - zypper up -y -l --auto-agree-with-product-licenses 2>&1>/dev/null

--- a/backend/caasp4os/terraform-os/master-instance.tf
+++ b/backend/caasp4os/terraform-os/master-instance.tf
@@ -1,0 +1,126 @@
+data "template_file" "master_repositories" {
+  template = "${file("cloud-init/repository.tpl")}"
+  count    = "${length(var.repositories)}"
+
+  vars {
+    repository_url  = "${element(values(var.repositories), count.index)}"
+    repository_name = "${element(keys(var.repositories), count.index)}"
+  }
+}
+
+data "template_file" "master_register_scc" {
+  template = "${file("cloud-init/register-scc.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+  }
+}
+
+data "template_file" "master_register_rmt" {
+  template = "${file("cloud-init/register-rmt.tpl")}"
+  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+
+  vars {
+    rmt_server_name = "${var.rmt_server_name}"
+  }
+}
+
+data "template_file" "master_register_ibs" {
+  template = "${file("cloud-init/register-ibs.tpl")}"
+}
+
+data "template_file" "master_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
+
+  vars {
+    packages = "${join(", ", var.packages)}"
+  }
+}
+
+data "template_file" "master-cloud-init" {
+  template = "${file("cloud-init/common.tpl")}"
+
+  vars {
+    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
+    repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
+    register_scc    = "${join("\n", data.template_file.master_register_scc.*.rendered)}"
+    register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
+    register_ibs    = "${join("\n", data.template_file.master_register_ibs.*.rendered)}"
+    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
+    username        = "${var.username}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  }
+}
+
+resource "openstack_compute_instance_v2" "master" {
+  count      = "${var.masters}"
+  name       = "caasp-master-${var.stack_name}-${count.index}"
+  image_name = "${var.image_name}"
+  key_pair   = "${var.key_pair}"
+
+  depends_on = [
+    "openstack_networking_network_v2.network",
+    "openstack_networking_subnet_v2.subnet",
+  ]
+
+  flavor_name = "${var.master_size}"
+
+  network {
+    name = "${var.internal_net}"
+  }
+
+  security_groups = [
+    "${openstack_networking_secgroup_v2.common.name}",
+    "${openstack_networking_secgroup_v2.master_nodes.name}",
+  ]
+
+  user_data = "${data.template_file.master-cloud-init.rendered}"
+}
+
+resource "openstack_networking_floatingip_v2" "master_ext" {
+  count = "${var.masters}"
+  pool  = "${var.external_net}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "master_ext_ip" {
+  count       = "${var.masters}"
+  floating_ip = "${element(openstack_networking_floatingip_v2.master_ext.*.address, count.index)}"
+  instance_id = "${element(openstack_compute_instance_v2.master.*.id, count.index)}"
+}
+
+resource "null_resource" "master_wait_cloudinit" {
+  depends_on = ["openstack_compute_instance_v2.master"]
+  count      = "${var.masters}"
+
+  connection {
+    host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+    user = "${var.username}"
+    type = "ssh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait > /dev/null",
+    ]
+  }
+}
+
+resource "null_resource" "master_reboot" {
+  depends_on = ["null_resource.master_wait_cloudinit"]
+  count      = "${var.masters}"
+
+  provisioner "local-exec" {
+    environment = {
+      user = "${var.username}"
+      host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+    }
+
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
+  }
+}

--- a/backend/caasp4os/terraform-os/storage-instance.tf
+++ b/backend/caasp4os/terraform-os/storage-instance.tf
@@ -11,19 +11,19 @@
 # Warning: This receipt consumes caasp4 templates and will not work outside
 # the caasp4 terraform environment.
 
-
 locals {
-  image = "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
-  flavor = "c4.large"
-  user = "opensuse"
+  image      = "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
+  flavor     = "c4.large"
+  user       = "opensuse"
   nfs_config = "rw,sync,no_subtree_check,no_root_squash,no_all_squash,insecure"
-  nfs_share = "/srv/nfs/kubedata"
+  nfs_share  = "/srv/nfs/kubedata"
+
   storage_packages = [
     "kernel-default",
     "-kernel-default-base",
     "nfs-client",
     "nfs-kernel-server",
-    "yast2-nfs-server"
+    "yast2-nfs-server",
   ]
 }
 
@@ -72,7 +72,7 @@ data "template_file" "storage-cloud-init" {
     register_scc    = ""
     register_rmt    = ""
     commands        = "${join("\n", data.template_file.storage_commands.*.rendered)}"
-    username        = "${local.user}" 
+    username        = "${local.user}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
@@ -107,7 +107,7 @@ resource "openstack_networking_floatingip_v2" "storage_ext" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "storage_ext_ip" {
-  count       = 1 
+  count       = 1
   floating_ip = "${element(openstack_networking_floatingip_v2.storage_ext.*.address, count.index)}"
   instance_id = "${element(openstack_compute_instance_v2.storage.*.id, count.index)}"
 }
@@ -224,7 +224,7 @@ resource "openstack_compute_secgroup_v2" "storage" {
 
   rule {
     from_port   = 2049
-    to_port     = 2049 
+    to_port     = 2049
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
@@ -237,7 +237,7 @@ resource "openstack_compute_secgroup_v2" "storage" {
   }
 
   rule {
-    from_port   = 33904 
+    from_port   = 33904
     to_port     = 33904
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
@@ -255,4 +255,3 @@ output "ip_storage_int" {
 output "storage_share" {
   value = "${local.nfs_share}"
 }
-

--- a/backend/caasp4os/terraform-os/storage-instance.tf
+++ b/backend/caasp4os/terraform-os/storage-instance.tf
@@ -55,6 +55,10 @@ data "template_file" "storage_register_rmt" {
   }
 }
 
+data "template_file" "storage_register_ibs" {
+  template = "${file("cloud-init/register-ibs.tpl")}"
+}
+
 data "template_file" "storage_commands" {
   template = "${file("cloud-init/commands.tpl")}"
 
@@ -71,6 +75,7 @@ data "template_file" "storage-cloud-init" {
     repositories    = ""
     register_scc    = ""
     register_rmt    = ""
+    register_ibs    = ""
     commands        = "${join("\n", data.template_file.storage_commands.*.rendered)}"
     username        = "${local.user}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"

--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -69,11 +69,15 @@ dnsentry = 0
 # }
 repositories = {
      #~placeholder_caasp_repo~#
-     sle15sp1_pool = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/"
-     sle15sp1_update = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/"
-     sle15_pool = "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
-     sle15_update = "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/"
-     suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
+    "caasp_product" = "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/",
+    "suse_ca" = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/",
+    "sle_server_pool" = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/",
+    "basesystem_pool" = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+    "containers_pool" = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/",
+    "sle_server_updates" = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/",
+    "basesystem_updates" = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+    "containers_updates" = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
+    "serverapps_updates" = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
 }
 
 # Minimum required packages. Do not remove them.

--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -86,8 +86,7 @@ packages = [
   "kernel-default",
   "-kernel-default-base",
   "ca-certificates-suse",
-  "nfs-client",
-  "#~placeholder_caasp_pattern~#"
+  "nfs-client"
 ]
 
 # ssh keys to inject into all the nodes

--- a/backend/caasp4os/terraform-os/worker-instance.tf
+++ b/backend/caasp4os/terraform-os/worker-instance.tf
@@ -1,0 +1,139 @@
+data "template_file" "worker_repositories" {
+  template = "${file("cloud-init/repository.tpl")}"
+  count    = "${length(var.repositories)}"
+
+  vars {
+    repository_url  = "${element(values(var.repositories), count.index)}"
+    repository_name = "${element(keys(var.repositories), count.index)}"
+  }
+}
+
+data "template_file" "worker_register_scc" {
+  template = "${file("cloud-init/register-scc.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+  }
+}
+
+data "template_file" "worker_register_rmt" {
+  template = "${file("cloud-init/register-rmt.tpl")}"
+  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+
+  vars {
+    rmt_server_name = "${var.rmt_server_name}"
+  }
+}
+
+data "template_file" "worker_register_ibs" {
+  template = "${file("cloud-init/register-ibs.tpl")}"
+}
+
+data "template_file" "worker_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
+
+  vars {
+    packages = "${join(", ", var.packages)}"
+  }
+}
+
+data "template_file" "worker-cloud-init" {
+  template = "${file("cloud-init/common.tpl")}"
+
+  vars {
+    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
+    repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
+    register_scc    = "${join("\n", data.template_file.worker_register_scc.*.rendered)}"
+    register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
+    register_ibs    = "${join("\n", data.template_file.worker_register_ibs.*.rendered)}"
+    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
+    username        = "${var.username}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  }
+}
+
+resource "openstack_blockstorage_volume_v2" "worker_vol" {
+  count = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
+  size  = "${var.workers_vol_size}"
+  name  = "vol_${element(openstack_compute_instance_v2.worker.*.name, count.index)}"
+}
+
+resource "openstack_compute_volume_attach_v2" "worker_vol_attach" {
+  count       = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
+  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
+  volume_id   = "${element(openstack_blockstorage_volume_v2.worker_vol.*.id, count.index)}"
+}
+
+resource "openstack_compute_instance_v2" "worker" {
+  count      = "${var.workers}"
+  name       = "caasp-worker-${var.stack_name}-${count.index}"
+  image_name = "${var.image_name}"
+  key_pair   = "${var.key_pair}"
+
+  depends_on = [
+    "openstack_networking_network_v2.network",
+    "openstack_networking_subnet_v2.subnet",
+  ]
+
+  flavor_name = "${var.worker_size}"
+
+  network {
+    name = "${var.internal_net}"
+  }
+
+  security_groups = [
+    "${openstack_networking_secgroup_v2.common.name}",
+    "${openstack_compute_secgroup_v2.secgroup_cap.name}",
+  ]
+
+  user_data = "${data.template_file.worker-cloud-init.rendered}"
+}
+
+resource "openstack_networking_floatingip_v2" "worker_ext" {
+  count = "${var.workers}"
+  pool  = "${var.external_net}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "worker_ext_ip" {
+  count       = "${var.workers}"
+  floating_ip = "${element(openstack_networking_floatingip_v2.worker_ext.*.address, count.index)}"
+  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
+}
+
+resource "null_resource" "worker_wait_cloudinit" {
+  depends_on = ["openstack_compute_instance_v2.worker"]
+  count      = "${var.workers}"
+
+  connection {
+    host    = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+    user    = "${var.username}"
+    type    = "ssh"
+    timeout = "10m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait > /dev/null",
+    ]
+  }
+}
+
+resource "null_resource" "worker_reboot" {
+  depends_on = ["null_resource.worker_wait_cloudinit"]
+  count      = "${var.workers}"
+
+  provisioner "local-exec" {
+    environment = {
+      user = "${var.username}"
+      host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+    }
+
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
+  }
+}


### PR DESCRIPTION
Default to CaaSP with update repositories when deploying it (CAASP_VER=update).

This PR build the skuba docker image into a sle15sp1, with all needed repos, product, and packages installed.
Patches the upstream CaaSP openstack terraform files to install the CaaSP product, update, and set swapaccount, and reboot, on all the nodes (see cloud-init/common.tpl and cloud-init/register-ibs.tpl).
