### PR TITLE
Let chart templates dictate count when HA is set

### DIFF
--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -106,6 +106,9 @@ enable:
 config:
   HA: ${HA}
 
+EOF
+if [ "${HA}" != "true" ]; then
+cat >> scf-config-values <<EOF
 sizing:
   uaa:
     count: ${SIZING}
@@ -174,6 +177,9 @@ sizing:
   secret_generation:
     count: 1
 
+EOF
+fi
+cat >> scf-config-values.yaml <<EOF
 kube:
   # The IP address assigned to the kube node pointed to by the domain.
   external_ips: [${external_ips}]


### PR DESCRIPTION
Trying to set these manually in gen-config causes conflicts in HA,
where some roles have their count set to 1 when they should be
scaled, or 2 when the minimum required by the chart is 3