### PR TITLE
Add yaml-patch as dependency

### DIFF
--- a/include/defaults_global.sh
+++ b/include/defaults_global.sh
@@ -17,3 +17,6 @@ export QUIET_OUTPUT="${QUIET_OUTPUT:-false}"
 
 # Download binaries of helm, kubectl, cf, etc
 DOWNLOAD_BINS="${DOWNLOAD_BINS:-true}"
+
+# Download binaries of catapult dependencies
+DOWNLOAD_CATAPULT_DEPS="${DOWNLOAD_CATAPULT_DEPS:-true}"

--- a/include/func.sh
+++ b/include/func.sh
@@ -176,3 +176,13 @@ function supported_backend {
         exit 1
     fi
 }
+
+function yamlpatch {
+    # we cannot use stdin to pass the file that yaml-patch is going to edit, or the
+    # file will change under its feet; use a temporal file
+    OP_FILE="$1"
+    PATCHED_FILE="$2"
+    cp "$PATCHED_FILE"{,.bak}
+    BAK_FILE="$PATCHED_FILE".bak
+    cat "$BAK_FILE" | yaml-patch -o "$OP_FILE" > "$PATCHED_FILE"; rm "$OP_FILE" "$BAK_FILE"
+}

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -14,10 +14,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export HELM_OS_TYPE="${HELM_OS_TYPE:-darwin-amd64}"
     export KUBECTL_OS_TYPE="${KUBECTL_OS_TYPE:-darwin}"
     export CFCLI_OS_TYPE="${CFCLI_OS_TYPE:-macosx64}"
+    export YAMLPATCH_OS_TYPE="${YAMLPATCH_OS_TYPE:-darwin}"
 else
     export HELM_OS_TYPE="${HELM_OS_TYPE:-linux-amd64}"
     export KUBECTL_OS_TYPE="${KUBECTL_OS_TYPE:-linux}"
     export CFCLI_OS_TYPE="${CFCLI_OS_TYPE:-linux64}"
+    export YAMLPATCH_OS_TYPE="${YAMLPATCH_OS_TYPE:-linux}"
 fi
 
 if [ ! -e "bin/helm" ]; then
@@ -43,10 +45,21 @@ if [ ! -e "bin/cf" ]; then
     cf version
 fi
 
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading catapult dependencies, using host binaries"
+    exit 0
+fi
+
 bazelpath=bin/bazel
 if [ ! -e "$bazelpath" ]; then
     wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64" -O $bazelpath
     chmod +x $bazelpath
+fi
+
+yamlpatchpath=bin/yaml-patch
+if [ ! -e "$yamlpatchpath" ]; then
+    wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_${YAMLPATCH_OS_TYPE}" -O $yamlpatchpath
+    chmod +x $yamlpatchpath
 fi
 
 ok "Deps correctly downloaded"

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -5,11 +5,6 @@
 . ../../include/common.sh
 . .envrc
 
-if [[ "$DOWNLOAD_BINS" == "false" ]]; then
-    ok "Skipping downloading bins, using host binaries"
-    exit 0
-fi
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export HELM_OS_TYPE="${HELM_OS_TYPE:-darwin-amd64}"
     export KUBECTL_OS_TYPE="${KUBECTL_OS_TYPE:-darwin}"
@@ -24,50 +19,56 @@ else
     export YQ_OS_TYPE="${YQ_OS_TYPE:-linux_amd64}"
 fi
 
-if [ ! -e "bin/helm" ]; then
-    curl -L https://get.helm.sh/helm-${HELM_VERSION}-${HELM_OS_TYPE}.tar.gz | tar zxf -
-    mv $HELM_OS_TYPE/helm bin/
-    mv $HELM_OS_TYPE/tiller bin/
-    rm -rf "$HELM_OS_TYPE"
-    helm version --client
+
+if [[ "$DOWNLOAD_BINS" == "false" ]]; then
+    ok "Skipping downloading bins, using host binaries"
+else
+    if [ ! -e "bin/helm" ]; then
+        curl -L https://get.helm.sh/helm-${HELM_VERSION}-${HELM_OS_TYPE}.tar.gz | tar zxf -
+        mv $HELM_OS_TYPE/helm bin/
+        mv $HELM_OS_TYPE/tiller bin/
+        rm -rf "$HELM_OS_TYPE"
+        helm version --client
+    fi
+
+    if [ ! -e "bin/kubectl" ]; then
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${KUBECTL_OS_TYPE}/amd64/kubectl
+        mv kubectl bin/
+        chmod +x bin/kubectl
+        kubectl version 2>&1 | grep Client || true
+    fi
+
+    if [ ! -e "bin/cf" ]; then
+        curl -L "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&source=github" | tar -zx
+        mv cf bin/
+        rm -rf "$CFCLI_OS_TYPE" LICENSE NOTICE
+        chmod +x bin/cf
+        cf version
+    fi
 fi
 
-if [ ! -e "bin/kubectl" ]; then
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${KUBECTL_OS_TYPE}/amd64/kubectl
-    mv kubectl bin/
-    chmod +x bin/kubectl
-    kubectl version 2>&1 | grep Client || true
-fi
-
-if [ ! -e "bin/cf" ]; then
-    curl -L "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&source=github" | tar -zx
-    mv cf bin/
-    rm -rf "$CFCLI_OS_TYPE" LICENSE NOTICE
-    chmod +x bin/cf
-    cf version
-fi
 
 if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
     ok "Skipping downloading catapult dependencies, using host binaries"
-    exit 0
+else
+    bazelpath=bin/bazel
+    if [ ! -e "$bazelpath" ]; then
+        wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64" -O $bazelpath
+        chmod +x $bazelpath
+    fi
+
+    yamlpatchpath=bin/yaml-patch
+    if [ ! -e "$yamlpatchpath" ]; then
+        wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_${YAMLPATCH_OS_TYPE}" -O $yamlpatchpath
+        chmod +x $yamlpatchpath
+    fi
+
+    yqpath=bin/yq
+    if [ ! -e "$yqpath" ]; then
+        wget "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_${YQ_OS_TYPE}" -O $yqpath
+        chmod +x $yqpath
+    fi
 fi
 
-bazelpath=bin/bazel
-if [ ! -e "$bazelpath" ]; then
-    wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64" -O $bazelpath
-    chmod +x $bazelpath
-fi
-
-yamlpatchpath=bin/yaml-patch
-if [ ! -e "$yamlpatchpath" ]; then
-    wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_${YAMLPATCH_OS_TYPE}" -O $yamlpatchpath
-    chmod +x $yamlpatchpath
-fi
-
-yqpath=bin/yq
-if [ ! -e "$yqpath" ]; then
-    wget "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_${YQ_OS_TYPE}" -O $yqpath
-    chmod +x $yqpath
-fi
 
 ok "Deps correctly downloaded"

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -6,7 +6,7 @@
 . .envrc
 
 if [[ "$DOWNLOAD_BINS" == "false" ]]; then
-    ok "Skipping downloading deps, using host binaries"
+    ok "Skipping downloading bins, using host binaries"
     exit 0
 fi
 

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -15,11 +15,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export KUBECTL_OS_TYPE="${KUBECTL_OS_TYPE:-darwin}"
     export CFCLI_OS_TYPE="${CFCLI_OS_TYPE:-macosx64}"
     export YAMLPATCH_OS_TYPE="${YAMLPATCH_OS_TYPE:-darwin}"
+    export YQ_OS_TYPE="${YQ_OS_TYPE:-darwin_amd64}"
 else
     export HELM_OS_TYPE="${HELM_OS_TYPE:-linux-amd64}"
     export KUBECTL_OS_TYPE="${KUBECTL_OS_TYPE:-linux}"
     export CFCLI_OS_TYPE="${CFCLI_OS_TYPE:-linux64}"
     export YAMLPATCH_OS_TYPE="${YAMLPATCH_OS_TYPE:-linux}"
+    export YQ_OS_TYPE="${YQ_OS_TYPE:-linux_amd64}"
 fi
 
 if [ ! -e "bin/helm" ]; then
@@ -60,6 +62,12 @@ yamlpatchpath=bin/yaml-patch
 if [ ! -e "$yamlpatchpath" ]; then
     wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_${YAMLPATCH_OS_TYPE}" -O $yamlpatchpath
     chmod +x $yamlpatchpath
+fi
+
+yqpath=bin/yq
+if [ ! -e "$yqpath" ]; then
+    wget "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_${YQ_OS_TYPE}" -O $yqpath
+    chmod +x $yqpath
 fi
 
 ok "Deps correctly downloaded"

--- a/modules/metrics/clean.sh
+++ b/modules/metrics/clean.sh
@@ -15,6 +15,6 @@ if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.da
     kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/metrics-chart"}]'
 fi
 
-rm -rf metrics stratos-metrics-values.yaml
+rm -rf metrics stratos-metrics-values.yaml scf-config-values-for-metrics.yaml
 
 ok "Stratos-metrics removed"

--- a/modules/metrics/install.sh
+++ b/modules/metrics/install.sh
@@ -9,7 +9,7 @@ info "Deploying stratos-metrics"
 helm install ./metrics \
      --name susecf-metrics \
      --namespace metrics \
-     --values scf-config-values-for-stratos.yaml \
+     --values scf-config-values-for-metrics.yaml \
      --values stratos-metrics-values.yaml
 
 bash "$ROOT_DIR"/include/wait_ns.sh metrics

--- a/modules/metrics/upgrade.sh
+++ b/modules/metrics/upgrade.sh
@@ -13,7 +13,7 @@ fi
 
 helm upgrade susecf-metrics ./metrics \
      --recreate-pods \
-     --values scf-config-values-for-stratos.yaml \
+     --values scf-config-values-for-metrics.yaml \
      --values stratos-metrics-values.yaml
 
 bash "$ROOT_DIR"/include/wait_ns.sh metrics

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -37,18 +37,15 @@ if [ -n "$SCF_HELM_VERSION" ]; then
 
     fi
 
-    # FIXME: Platform hardcoded for now - should we have a global deps step?
-    [ ! -e "bin/yq" ] && wget https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -O bin/yq && chmod +x bin/yq
-
     mkdir -p charts/helm
     tar xvf cf-*.tgz -C charts/helm
     tar xvf uaa-*.tgz -C charts/helm
     pushd charts
-        VERSION=$(../bin/yq r helm/cf/Chart.yaml version)
-        API_VERSION=$(../bin/yq r helm/cf/Chart.yaml apiVersion)
+        VERSION=$(yq r helm/cf/Chart.yaml version)
+        API_VERSION=$(yq r helm/cf/Chart.yaml apiVersion)
 
         if [ "${API_VERSION}" == "v1" ]; then
-            API_VERSION=$(../bin/yq r helm/cf/Chart.yaml scfVersion)
+            API_VERSION=$(yq r helm/cf/Chart.yaml scfVersion)
         fi
 
         if [ -z "$VERSION" ]; then

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -42,10 +42,7 @@ elif [ "${SCF_OPERATOR}" == "true" ]; then
 
     if [ "$OPERATOR_CHART_URL" = latest ]; then
         info "Sourcing operator from kubecf charts"
-        # FIXME: Platform dipendent for now
         info "Getting latest cf-operator chart (override with OPERATOR_CHART_URL)"
-        [ ! -e "bin/yq" ] && wget https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -O bin/yq && chmod +x bin/yq
-
         OPERATOR_CHART_URL=$(yq r $SCF_CHART/Metadata.yaml operatorChartUrl)
 
         # If still empty, grab latest one

--- a/modules/stratos/gen-config.sh
+++ b/modules/stratos/gen-config.sh
@@ -7,13 +7,31 @@ info "Generating stratos config values from scf values"
 
 cp scf-config-values.yaml scf-config-values-for-stratos.yaml
 
-cat <<HEREDOC_APPEND >> scf-config-values-for-stratos.yaml
+cat <<EOF > op.yml
+- op: add
+  path: /console
+  value:
+    service:
+      ingress:
+        enabled: true
+- op: replace
+  path: /kube/registry/hostname
+  value:
+    "${DOCKER_REGISTRY}"
+- op: replace
+  path: /kube/registry/username
+  value:
+    "${DOCKER_USERNAME}"
+- op: replace
+  path: /kube/registry/password
+  value:
+    "${DOCKER_PASSWORD}"
+- op: replace
+  path: /kube/organization
+  value:
+    "${DOCKER_ORG}"
+EOF
 
-# Appended for stratos:
-console:
-  service:
-    ingress:
-      enabled: true
-HEREDOC_APPEND
+yamlpatch op.yml scf-config-values-for-stratos.yaml
 
 ok "Stratos config values generated"

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -174,6 +174,23 @@ testCommonDeps() {
 
   make clean
   assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
+
+  make buildir
+  DOWNLOAD_BINS=false DOWNLOAD_CATAPULT_DEPS=false make private modules/common
+
+  assertFalse 'bazel not downloaded' "[ -e 'buildtest/bin/bazel' ]"
+  assertFalse 'yaml-patch not downloaded' "[ -e 'buildtest/bin/yaml-patch' ]"
+  assertFalse 'yq not downloaded' "[ -e 'buildtest/bin/yq' ]"
+
+  make clean
+  assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
+
+  make buildir
+  DOWNLOAD_BINS=false make private modules/common
+
+  assertTrue 'bazel downloaded' "[ -e 'buildtest/bin/bazel' ]"
+  assertTrue 'yaml-patch downloaded' "[ -e 'buildtest/bin/yaml-patch' ]"
+  assertTrue 'yq downloaded' "[ -e 'buildtest/bin/yq' ]"
 }
 
 # Load shUnit2.

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -150,18 +150,18 @@ testJsonOverrides() {
 testCommonDeps() {
   rm -rf buildtest
   make buildir
-  DOWNLOAD_BINS=false make private modules/common
+  DOWNLOAD_BINS=false DOWNLOAD_CATAPULT_DEPS=false make private modules/common
 
-  assertFalse 'helm downloaded' "[ -e 'buildtest/bin/helm' ]"
-  assertFalse 'tiller downloaded' "[ -e 'buildtest/bin/tiller' ]"
-  assertFalse 'kubectl downloaded' "[ -e 'buildtest/bin/kubectl' ]"
-  assertFalse 'cfcli downloaded' "[ -e 'buildtest/bin/cf' ]"
+  assertFalse 'helm not downloaded' "[ -e 'buildtest/bin/helm' ]"
+  assertFalse 'tiller not downloaded' "[ -e 'buildtest/bin/tiller' ]"
+  assertFalse 'kubectl not downloaded' "[ -e 'buildtest/bin/kubectl' ]"
+  assertFalse 'cfcli not downloaded' "[ -e 'buildtest/bin/cf' ]"
 
   make clean
   assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
 
   make buildir
-  make private modules/common
+  DOWNLOAD_CATAPULT_DEPS=false make private modules/common
 
   assertTrue 'helm downloaded' "[ -e 'buildtest/bin/helm' ]"
   assertTrue 'tiller downloaded' "[ -e 'buildtest/bin/tiller' ]"


### PR DESCRIPTION
Add yaml-patch (https://github.com/krishicks/yaml-patch) as catapult dependency,
and use it for patching stratos and metrics configs, see `{stratos,metrics}/gen_config.sh`.

Add global option `DOWNLOAD_CATAPULT_DEPS`, to skip download of `bazel`, `yaml-patch` and the like, as ideally they should come from the system/docker image, to not download hundreds of MBs every time one creates a cluster.