### PR TITLE
Add required config options to make stratos work on kubecf

### DIFF
--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -54,9 +54,14 @@ features:
     enabled: ${ENABLE_EIRINI}
 
 kube:
-  storage_class: ~
   service_cluster_ip_range: 0.0.0.0/0
   pod_cluster_ip_range: 0.0.0.0/0
+
+  registry:
+    hostname: "${DOCKER_REGISTRY}"
+    username: "${DOCKER_USERNAME}"
+    password: "${DOCKER_PASSWORD}"
+  organization: "${DOCKER_ORG}"
 
 ${CONFIG_OVERRIDE}
 

--- a/modules/stratos/gen-config.sh
+++ b/modules/stratos/gen-config.sh
@@ -6,14 +6,18 @@
 info "Generating stratos config values from scf values"
 
 cp scf-config-values.yaml scf-config-values-for-stratos.yaml
+public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
 
 cat <<EOF > op.yml
 - op: add
   path: /console
   value:
     service:
+      externalIPs: ["${public_ip}"]
+      servicePort: 8443
       ingress:
         enabled: true
+        host: ${public_ip}.nip.io
 - op: replace
   path: /kube/registry/hostname
   value:


### PR DESCRIPTION
- For Stratos we need to have a registry section and an external ip in the config.yaml in order to have `make stratos-gen-config` work  again and get a stratos deployment with an external ip to connect to.
- When enabling ingress for Stratos, a ingress hostname is required. In 1.5 this was retrieved from the DOMAIN value, but that does not exist for kubecf anymore it seems, thus I moved it into the console/service block.
- The storage class entry was removed as it seems to have no function for kubecf and does break the Stratos deployment as Stratos can't handle a null value here.

Alternatively it would also be possible to add the whole registry block via the stratos gen-config script and not have it created in the scf gen_config.sh The question here would be if it might also be beneficial for kubecf in catapult to have it in or not.