### PR TITLE
Fix extracting kubecf-bundle.tgz

### DIFF
--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -81,8 +81,10 @@ else
 fi
 
 if  [ "${SCF_OPERATOR}" == "true" ]; then
-    tar xvzf cf-operator*.tgz
-    tar xvzf kubecf*.tgz
+    if echo "$SCF_CHART" | grep -q "bundle"; then
+        tar xvzf cf-operator*.tgz
+        tar xvzf kubecf*.tgz
+    fi
     cp -rfv kubecf*/* ./
 fi
 

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -81,6 +81,8 @@ else
 fi
 
 if  [ "${SCF_OPERATOR}" == "true" ]; then
+    tar xvzf cf-operator*.tgz
+    tar xvzf kubecf*.tgz
     cp -rfv kubecf*/* ./
 fi
 


### PR DESCRIPTION
I'm not sure this breaks something as I'm not fully sure if we still would have non bundled charts for kubecf.