### PR TITLE
Increase shellcheck severity to warning, fix bugs

### DIFF
--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -75,7 +75,7 @@ sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
     deployment/terraform.tfvars
 cp -r "$ROOT_DIR"/backend/caasp4os/terraform-os/* deployment/
 
-pushd deployment
+pushd deployment || exit
 
 info "Deploying infrastructure with terraform…"
 

--- a/backend/caasp4os/destroy.sh
+++ b/backend/caasp4os/destroy.sh
@@ -27,12 +27,12 @@ if [ -d "$BUILD_DIR" ]; then
         fi
         skuba_container terraform destroy -auto-approve
         info "Terraform infrastructure destroyed"
-        popd
+        popd || exit
     else
         info "No Terraform infrastructure present"
     fi
 
-    popd
+    popd || exit
     rm -rf "$BUILD_DIR"
 fi
 ok "CaaSP4 on Openstack succesfully destroyed!"

--- a/backend/caasp4os/destroy.sh
+++ b/backend/caasp4os/destroy.sh
@@ -20,7 +20,7 @@ if [ -d "$BUILD_DIR" ]; then
     fi
 
     if [ -d deployment ]; then
-        pushd deployment
+        pushd deployment || exit
         info "Destroying infrastructure with Terraform…"
         if [[ ! -v OS_PASSWORD ]]; then
             err "Missing openstack credentials" && exit 1

--- a/backend/caasp4os/docker/skuba/build.sh
+++ b/backend/caasp4os/docker/skuba/build.sh
@@ -5,7 +5,8 @@ REPO="$2"
 VERSION=
 
 retrieve_version() {
-  local output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/ caasp4-product && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
+  local output
+  output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/ caasp4-product && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
 
   if [[ $? -eq 0 ]]; then
     # 0.5.0-1.2 ^M$

--- a/backend/caasp4os/docker_skuba.sh
+++ b/backend/caasp4os/docker_skuba.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 . ../../include/common.sh
-pushd  "$ROOT_DIR"/backend/caasp4os
+pushd  "$ROOT_DIR"/backend/caasp4os || exit
 . defaults.sh
 
 set -Eeuo pipefail

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -7,10 +7,14 @@ SKUBA_CLUSTER_NAME="$CLUSTER_NAME"
 
 _set_env_vars() {
     JSON=$(skuba_container terraform output -json)
-    export LB="$(echo "$JSON" | jq -r '.ip_load_balancer.value')"
-    export MASTERS="$(echo "$JSON" | jq -r '.ip_masters.value|@tsv')"
-    export WORKERS="$(echo "$JSON" | jq -r '.ip_workers.value|@tsv')"
-    export ALL="$MASTERS $WORKERS"
+    LB="$(echo "$JSON" | jq -r '.ip_load_balancer.value')"
+    export LB
+    MASTERS="$(echo "$JSON" | jq -r '.ip_masters.value|@tsv')"
+    export MASTERS
+    WORKERS="$(echo "$JSON" | jq -r '.ip_workers.value|@tsv')"
+    export WORKERS
+    ALL="$MASTERS $WORKERS"
+    export ALL
 }
 
 _define_node_group() {
@@ -166,7 +170,8 @@ _init_control_plane() {
 _deploy_masters() {
 local i=0
 for n in $1; do
-    local j="$(printf "%03g" $i)"
+    local j
+    j="$(printf "%03g" $i)"
     if [[ $i -eq 0 ]]; then
       skuba_container "$SKUBA_CLUSTER_NAME" skuba node bootstrap --user sles --sudo --target "$n" "master$j" -v "$DEBUG"
       wait
@@ -183,7 +188,8 @@ done
 _deploy_workers() {
     local i=0
     for n in $1; do
-        local j="$(printf "%03g" $i)"
+        local j
+        j="$(printf "%03g" $i)"
         (skuba_container "$SKUBA_CLUSTER_NAME" skuba node join --role worker --user sles --sudo --target  "$n" "worker$j" -v "$DEBUG") &
         wait
         ((++i))

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -196,7 +196,7 @@ skuba_deploy() {
     local KUBECONFIG=""
     _set_env_vars
     _init_control_plane
-    pushd $(pwd)/
+    pushd $(pwd)/ || exit
     _deploy_masters "$MASTERS"
     _deploy_workers "$WORKERS"
     skuba_container $SKUBA_CLUSTER_NAME skuba cluster status

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -202,7 +202,7 @@ skuba_deploy() {
     local KUBECONFIG=""
     _set_env_vars
     _init_control_plane
-    pushd $(pwd)/ || exit
+    pushd "$(pwd)"/ || exit
     _deploy_masters "$MASTERS"
     _deploy_workers "$WORKERS"
     skuba_container $SKUBA_CLUSTER_NAME skuba cluster status

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -36,7 +36,7 @@ _define_node_group() {
 }
 
 DEBUG_MODE=${DEBUG_MODE:-false}
-if [ DEBUG_MODE = true ]; then
+if [ $DEBUG_MODE = true ]; then
     DEBUG=1
 else
     DEBUG=0

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -199,13 +199,12 @@ _deploy_workers() {
 skuba_deploy() {
     # Usage: deploy
 
-    local KUBECONFIG=""
     _set_env_vars
     _init_control_plane
     pushd "$(pwd)"/ || exit
     _deploy_masters "$MASTERS"
     _deploy_workers "$WORKERS"
-    skuba_container $SKUBA_CLUSTER_NAME skuba cluster status
+    KUBECONFIG="" skuba_container $SKUBA_CLUSTER_NAME skuba cluster status
 }
 
 skuba_node_upgrade() {

--- a/backend/ekcp/clean.sh
+++ b/backend/ekcp/clean.sh
@@ -6,7 +6,7 @@
 if [ -d "$BUILD_DIR" ]; then
       . .envrc
       curl -X DELETE http://"$EKCP_HOST"/"${CLUSTER_NAME}"
-      popd
+      popd || exit
       rm -rf "$BUILD_DIR"
 fi
 

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -12,10 +12,10 @@ if [ -d "$BUILD_DIR" ]; then
     if [ -d "cap-terraform/eks" ]; then
         pushd cap-terraform/eks
         terraform destroy -auto-approve
-        popd
+        popd || exit
         rm -rf cap-terraform
     fi
 
-    popd
+    popd || exit
     rm -rf "$BUILD_DIR"
 fi

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -10,7 +10,7 @@ if [ -d "$BUILD_DIR" ]; then
 
 
     if [ -d "cap-terraform/eks" ]; then
-        pushd cap-terraform/eks
+        pushd cap-terraform/eks || exit
         terraform destroy -auto-approve
         popd || exit
         rm -rf cap-terraform

--- a/backend/eks/defaults.sh
+++ b/backend/eks/defaults.sh
@@ -6,5 +6,5 @@
 EKS_LOCATION="${EKS_LOCATION:-us-west-2}"
 EKS_KEYPAIR="${EKS_KEYPAIR:-$(whoami)-terraform}"
 EKS_VERS="${EKS_VERS:-1.14}"
-EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-{key = \"$(whoami)-eks-cluster\"}}
+EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-\{key = \"$(whoami)-eks-cluster\"\}}
 # EKS_KUBECTL_VERSION not to be defined as the eks kubectl is hardcoded in deps.sh

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -12,7 +12,7 @@ if ! aws sts get-caller-identity ; then
 fi
 
 git clone https://github.com/SUSE/cap-terraform.git
-pushd cap-terraform/eks
+pushd cap-terraform/eks || exit
 
 # terraform needs helm client installed and configured:
 helm init --client-only

--- a/backend/eks/deps.sh
+++ b/backend/eks/deps.sh
@@ -16,7 +16,7 @@ chmod +x kubectl && mv kubectl bin/
 mkdir -p .local
 curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
-./awscli-bundle/install --install-dir=$(pwd)/.local/ --bin-location=$(pwd)/bin/aws
+./awscli-bundle/install --install-dir="$(pwd)"/.local/ --bin-location="$(pwd)"/bin/aws
 rm -rf awscli-bundle*
 
 curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator

--- a/backend/gke/clean.sh
+++ b/backend/gke/clean.sh
@@ -14,9 +14,9 @@ if [ -d "$BUILD_DIR" ]; then
     if [ -d "cap-terraform/gke" ]; then
         pushd cap-terraform/gke
         terraform destroy -auto-approve
-        popd
+        popd || exit
     fi
 
-    popd
+    popd || exit
     rm -rf "$BUILD_DIR"
 fi

--- a/backend/gke/clean.sh
+++ b/backend/gke/clean.sh
@@ -12,7 +12,7 @@ if [ -d "$BUILD_DIR" ]; then
     . .envrc
 
     if [ -d "cap-terraform/gke" ]; then
-        pushd cap-terraform/gke
+        pushd cap-terraform/gke || exit
         terraform destroy -auto-approve
         popd || exit
     fi

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -18,7 +18,7 @@ fi
 #        --role=roles/container.admin
 
 git clone https://github.com/SUSE/cap-terraform.git
-pushd cap-terraform/gke
+pushd cap-terraform/gke || exit
 
 cat <<HEREDOC > terraform.tfvars
 project = "$GKE_PROJECT"

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -39,7 +39,7 @@ terraform init
 terraform plan -out="$(pwd)"/my-plan
 
 terraform apply -auto-approve
-popd
+popd || exit
 
 # wait for cluster ready:
 wait_ns kube-system

--- a/backend/gke/deps.sh
+++ b/backend/gke/deps.sh
@@ -11,7 +11,7 @@ fi
 curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz
 tar -xvf google-cloud-sdk.tar.gz
 rm google-cloud-sdk.tar.gz
-pushd google-cloud-sdk
+pushd google-cloud-sdk || exit
 bash ./install.sh -q
 popd || exit
 echo "source $(pwd)/google-cloud-sdk/path.bash.inc" >> .envrc

--- a/backend/gke/deps.sh
+++ b/backend/gke/deps.sh
@@ -13,7 +13,7 @@ tar -xvf google-cloud-sdk.tar.gz
 rm google-cloud-sdk.tar.gz
 pushd google-cloud-sdk
 bash ./install.sh -q
-popd
+popd || exit
 echo "source $(pwd)/google-cloud-sdk/path.bash.inc" >> .envrc
 
 curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip

--- a/backend/imported/clean.sh
+++ b/backend/imported/clean.sh
@@ -8,6 +8,6 @@
 info "Deleting imported k8s cluster"
 
 if [ -d "$BUILD_DIR" ]; then
-    popd
+    popd || exit
     rm -rf "$BUILD_DIR"
 fi

--- a/backend/kind/clean.sh
+++ b/backend/kind/clean.sh
@@ -8,7 +8,7 @@ if [ -d "$BUILD_DIR" ]; then
       if kind get clusters | grep -qi "${CLUSTER_NAME}" ; then
           kind delete cluster --name="${CLUSTER_NAME}"
       fi
-      popd
+      popd || exit
       rm -rf "$BUILD_DIR"
 fi
 

--- a/backend/kind/deps.sh
+++ b/backend/kind/deps.sh
@@ -22,6 +22,6 @@ fi
 chmod +x kind
 mv kind bin/kind
 
-popd
+popd || exit
 
 ok "Deps correctly downloaded"

--- a/backend/kind/docker_kubeconfig.sh
+++ b/backend/kind/docker_kubeconfig.sh
@@ -3,8 +3,8 @@
 . ../../include/common.sh
 . .envrc
 
-export container_id=$(docker ps -f "name=${CLUSTER_NAME}-control-plane" -q)
-export container_ip=$(docker inspect $container_id | jq -r .[0].NetworkSettings.Networks.bridge.IPAddress)
+container_id=$(docker ps -f "name=${CLUSTER_NAME}-control-plane" -q)
+container_ip=$(docker inspect $container_id | jq -r .[0].NetworkSettings.Networks.bridge.IPAddress)
 
 # Tweaks the kubeconfig so it can be called from the docker container network (in case the cluster is created with dind)
 sed -i "s/localhost.*/${container_ip}:6443/" kubeconfig

--- a/backend/kind/kubeconfig.sh
+++ b/backend/kind/kubeconfig.sh
@@ -5,7 +5,7 @@
 
 # Kind above version 0.6.0 generates the config itself
 if [ ! -f kubeconfig ]; then
-  cp $(kind get kubeconfig-path --name="$CLUSTER_NAME") kubeconfig
+  cp "$(kind get kubeconfig-path --name="$CLUSTER_NAME")" kubeconfig
 
   ok "Kubeconfig copied"
 fi

--- a/backend/kind/up_if_not_exists.sh
+++ b/backend/kind/up_if_not_exists.sh
@@ -32,7 +32,7 @@ if [ -n "$EKCP_HOST" ]; then
       echo "Remote cluster already exists, skipping creation"
     fi
 else
-  if [ -z $(kind get clusters | grep ${CLUSTER_NAME}) ]; then
+  if [ -z "$(kind get clusters | grep ${CLUSTER_NAME})" ]; then
     echo "Local cluster doesn't exist, creating now"
     kind create cluster --config kind-config.yaml --name=${CLUSTER_NAME}
   else

--- a/backend/minikube/clean.sh
+++ b/backend/minikube/clean.sh
@@ -10,7 +10,7 @@ if [ -d "$BUILD_DIR" ]; then
     set +x
     minikube delete || true
     set -x
-    popd
+    popd || exit
 
     rm -rf "$BUILD_DIR"
 fi

--- a/backend/minikube/deps.sh
+++ b/backend/minikube/deps.sh
@@ -19,4 +19,4 @@ chmod +x minikube && mv minikube bin/
 curl -Lo docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
 chmod +x docker-machine-driver-kvm2 && mv docker-machine-driver-kvm2 bin/
 
-popd
+popd || exit

--- a/include/buildir.sh
+++ b/include/buildir.sh
@@ -55,4 +55,4 @@ for d in "$ROOT_DIR"/modules/*/ ; do
     fi
 done
 
-popd
+popd || exit

--- a/include/common.sh
+++ b/include/common.sh
@@ -9,13 +9,14 @@ if [ -n "$CONFIG" ]; then
   load_env_from_json "$CONFIG"
 fi
 
-export BACKEND="${BACKEND:-kind}"
 export VALUES_OVERRIDE="${VALUES_OVERRIDE:-}"
 OVERRIDE=
 if [ -n "$VALUES_OVERRIDE" ] && [ -f "$VALUES_OVERRIDE" ]; then
   OVERRIDE=$(cat "$VALUES_OVERRIDE")
+  export OVERRIDE
 fi
 
+export BACKEND="${BACKEND:-kind}"
 export CLUSTER_NAME=${CLUSTER_NAME:-$BACKEND}
 #export ROOT_DIR="$(git rev-parse --show-toplevel)"
 export BUILD_DIR="$ROOT_DIR"/build${CLUSTER_NAME}

--- a/include/common.sh
+++ b/include/common.sh
@@ -21,7 +21,7 @@ export CLUSTER_NAME=${CLUSTER_NAME:-$BACKEND}
 export BUILD_DIR="$ROOT_DIR"/build${CLUSTER_NAME}
 
 # Forces our build context
-[ -d "$BUILD_DIR" ] && pushd "$BUILD_DIR"
+[ -d "$BUILD_DIR" ] && pushd "$BUILD_DIR" || true
 
 . "$ROOT_DIR"/include/defaults_global.sh
 set +x

--- a/include/defaults_global.sh
+++ b/include/defaults_global.sh
@@ -16,7 +16,7 @@ export KUBEPROXY_PORT="${KUBEPROXY_PORT:-2224}"
 export QUIET_OUTPUT="${QUIET_OUTPUT:-false}"
 
 # Download binaries of helm, kubectl, cf, etc
-DOWNLOAD_BINS="${DOWNLOAD_BINS:-true}"
+export DOWNLOAD_BINS="${DOWNLOAD_BINS:-true}"
 
 # Download binaries of catapult dependencies
-DOWNLOAD_CATAPULT_DEPS="${DOWNLOAD_CATAPULT_DEPS:-true}"
+export DOWNLOAD_CATAPULT_DEPS="${DOWNLOAD_CATAPULT_DEPS:-true}"

--- a/include/func.sh
+++ b/include/func.sh
@@ -100,6 +100,7 @@ On_IWhite='\033[0;107m'   # White
 function simple {
     local cat="$2"
     local message="$1"
+    # shellcheck disable=SC2153 #BACKEND comes from env
     echo "[$cat] [backend:$BACKEND] [cluster:${CLUSTER_NAME}] $message"
 }
 

--- a/include/func.sh
+++ b/include/func.sh
@@ -106,7 +106,7 @@ function simple {
 
 function info {
     set +x
-    local message="$@"
+    local message="$*"
 
     cat=$0
 
@@ -120,7 +120,7 @@ function info {
 
 function ok {
     set +x
-    local message="$@"
+    local message="$*"
 
     cat=$0
 
@@ -134,7 +134,7 @@ function ok {
 
 function warn {
     set +x
-    local message="$@"
+    local message="$*"
 
     cat=$0
 
@@ -148,7 +148,7 @@ function warn {
 
 function err {
     set +x
-    local message="$@"
+    local message="$*"
 
     cat=$0
 

--- a/include/func.sh
+++ b/include/func.sh
@@ -22,6 +22,8 @@ if ((BASH_VERSINFO[0] >= 4)) && [[ $'\u2388 ' != "\\u2388 " ]]; then
         OK_IMG=$'\xE2\x9C\x85 '
 fi
 
+#shellcheck disable=SC2034
+{
 # Reset
 Color_Off='\033[0m'       # Text Reset
 # Regular Colors
@@ -93,6 +95,7 @@ On_IBlue='\033[0;104m'    # Blue
 On_IPurple='\033[0;105m'  # Purple
 On_ICyan='\033[0;106m'    # Cyan
 On_IWhite='\033[0;107m'   # White
+}
 
 function simple {
     local cat="$2"

--- a/include/versioning.sh
+++ b/include/versioning.sh
@@ -11,7 +11,7 @@ GIT_TAG=${GIT_TAG:-$(echo ${GIT_DESCRIBE} | gawk -F - '{ print $1 }' )}
 GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | gawk -F - '{ print $2 }' )}
 GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | gawk -F - '{ print $3 }' )}
 
-ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^scf-//)}
+ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename "$(git config --get remote.origin.url)" .git | sed s/^scf-//)}
 ARTIFACT_VERSION=${GIT_TAG}.${GIT_COMMITS}.${GIT_SHA}
 else
 # shellcheck disable=SC2034

--- a/include/versioning.sh
+++ b/include/versioning.sh
@@ -14,5 +14,6 @@ GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | gawk -F - '{ print $3 }' )}
 ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^scf-//)}
 ARTIFACT_VERSION=${GIT_TAG}.${GIT_COMMITS}.${GIT_SHA}
 else
+# shellcheck disable=SC2034
 ARTIFACT_VERSION=latest
 fi

--- a/kube/brats/pod.yaml.erb
+++ b/kube/brats/pod.yaml.erb
@@ -32,7 +32,7 @@ spec:
           git config --global user.name "johndoe"
 
           git clone --recurse-submodules https://github.com/SUSE/cf-${BRATS_BUILDPACK}-buildpack.git
-          pushd cf-${BRATS_BUILDPACK}-buildpack
+          pushd cf-${BRATS_BUILDPACK}-buildpack || exit
           git checkout "${BRATS_BUILDPACK_VERSION}"
           git submodule sync --recursive && \
           git submodule update --init --recursive && \

--- a/kube/cats/pod.yaml.erb
+++ b/kube/cats/pod.yaml.erb
@@ -22,7 +22,7 @@ spec:
 
           git clone $CATS_REPO
 
-          pushd cf-acceptance-tests
+          pushd cf-acceptance-tests || exit
           cat > config.json <<EOF
           {
             "api"                             : "api.${DOMAIN}",
@@ -82,7 +82,7 @@ spec:
 
           mkdir -p "$GOPATH"/src/github.com/cloudfoundry
           ln -s "$PWD" "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests
-          pushd "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests
+          pushd "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests || exit
           go get github.com/onsi/ginkgo/ginkgo
           go install github.com/onsi/ginkgo/ginkgo
           CONFIG="$PWD"/config.json ./bin/test

--- a/kube/smokes/pod.yaml.erb
+++ b/kube/smokes/pod.yaml.erb
@@ -18,7 +18,7 @@ spec:
 
           git clone $SMOKES_REPO
 
-          pushd cf-smoke-tests
+          pushd cf-smoke-tests || exit
           cat > config.json <<EOF
           {
             "suite_name"                      : "CF_SMOKE_TESTS",
@@ -48,7 +48,7 @@ spec:
 
           mkdir -p "$GOPATH"/src/github.com/cloudfoundry
           ln -s "$PWD" "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests
-          pushd "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests
+          pushd "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests || exit
 
           CONFIG="$PWD"/config.json ./bin/test
       env:

--- a/modules/experimental/eirini_release.sh
+++ b/modules/experimental/eirini_release.sh
@@ -76,7 +76,7 @@ fi
 pushd eirini
 git checkout ${EIRINI_RELEASE_CHECKOUT}
 git pull
-popd
+popd || exit
 
 helm fetch eirini/cf
 tar xzvf eirini-cf.tgz
@@ -85,7 +85,7 @@ tar xvfz eirini-*.tgz
 cp ../../eirini/helm/eirini/templates/eirini-loggregator-bridge.yaml eirini/templates
 tar cvfz eirini-*.tgz eirini
 rm -rf eirini
-popd
+popd || exit
 
 helm install eirini/uaa --namespace uaa --name uaa --values eirini-values.yaml
 bash ../scripts/wait.sh uaa

--- a/modules/experimental/eirini_release.sh
+++ b/modules/experimental/eirini_release.sh
@@ -73,14 +73,14 @@ helm repo add eirini https://cloudfoundry-incubator.github.io/eirini-release
 if [ ! -d eirini ]; then
   git clone $EIRINI_RELEASE_REPO eirini
 fi
-pushd eirini
+pushd eirini || exit
 git checkout ${EIRINI_RELEASE_CHECKOUT}
 git pull
 popd || exit
 
 helm fetch eirini/cf
 tar xzvf eirini-cf.tgz
-pushd cf/charts
+pushd cf/charts || exit
 tar xvfz eirini-*.tgz
 cp ../../eirini/helm/eirini/templates/eirini-loggregator-bridge.yaml eirini/templates
 tar cvfz eirini-*.tgz eirini

--- a/modules/experimental/eirinifs.sh
+++ b/modules/experimental/eirinifs.sh
@@ -7,20 +7,20 @@
 . .envrc
 
 [ ! -d "eirinifs" ] && git clone --recurse-submodules "${EIRINIFS}"
-pushd eirinifs
+pushd eirinifs || exit
 git pull
 popd || exit
 [ ! -d "diego-ssh" ] && git clone --recurse-submodules "${EIRINISSH}"
-pushd diego-ssh
+pushd diego-ssh || exit
 git pull
 popd || exit
 
-pushd diego-ssh/cmd/sshd
+pushd diego-ssh/cmd/sshd || exit
 go build
 popd || exit
 
 cp -rfv diego-ssh/cmd/sshd/sshd eirinifs/image
-pushd eirinifs
+pushd eirinifs || exit
 
 docker run --rm --privileged -it --workdir / -v $PWD:/eirinifs eirini/ci /bin/bash -c "/eirinifs/ci/build-eirinifs/task.sh && mv /go/src/github.com/cloudfoundry-incubator/eirinifs/image/eirinifs.tar /eirinifs/image"
 

--- a/modules/experimental/eirinifs.sh
+++ b/modules/experimental/eirinifs.sh
@@ -9,15 +9,15 @@
 [ ! -d "eirinifs" ] && git clone --recurse-submodules "${EIRINIFS}"
 pushd eirinifs
 git pull
-popd
+popd || exit
 [ ! -d "diego-ssh" ] && git clone --recurse-submodules "${EIRINISSH}"
 pushd diego-ssh
 git pull
-popd
+popd || exit
 
 pushd diego-ssh/cmd/sshd
 go build
-popd
+popd || exit
 
 cp -rfv diego-ssh/cmd/sshd/sshd eirinifs/image
 pushd eirinifs
@@ -26,5 +26,5 @@ docker run --rm --privileged -it --workdir / -v $PWD:/eirinifs eirini/ci /bin/ba
 
 sudo chmod 777 image/eirinifs.tar &&  kubectl cp image/eirinifs.tar scf/bits-0:/var/vcap/store/bits-service/assets/eirinifs.tar
 
-popd
+popd || exit
 kubectl exec -it -n scf bits-0 -- bash -c -l "monit restart bits-service"

--- a/modules/extra/concourse.sh
+++ b/modules/extra/concourse.sh
@@ -11,7 +11,7 @@ CONCOURSE_DRIVER="${CONCOURSE_DRIVER:-btrfs}"
 info "Deploying concourse from the helm charts"
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
-aux_external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
+aux_external_ips=("$(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address')")
 external_ips+="\"$public_ip\""
 for (( i=0; i < ${#aux_external_ips[@]}; i++ )); do
 external_ips+=", \"${aux_external_ips[$i]}\""

--- a/modules/extra/concourse.sh
+++ b/modules/extra/concourse.sh
@@ -53,7 +53,8 @@ wait_ns default
 
 if [ "${LOCAL_ACCESS}" == "true" ]; then
 
-    export POD_NAME=$(kubectl get pods --namespace default -l "app=catapult-concourse-web" -o jsonpath="{.items[0].metadata.name}")
+    POD_NAME=$(kubectl get pods --namespace default -l "app=catapult-concourse-web" -o jsonpath="{.items[0].metadata.name}")
+    export POD_NAME
 
     info "After exiting, if you want to access Concourse, do: 'kubectl port-forward --namespace default $POD_NAME 8080:80'"
     ok "All done"

--- a/modules/extra/fissile.sh
+++ b/modules/extra/fissile.sh
@@ -12,11 +12,11 @@ if [ ! -e "bin/fissile" ]; then
     # Takes a dev bosh release checkout and make it an image. Upload it also to the kind cluster
     info "Building fissile from develop"
     mkdir -p buildfissile
-    pushd buildfissile
+    pushd buildfissile || exit
     mkdir -p src                                  # make the directory src in your workspace
     export GOPATH=$PWD                            # set GOPATH to current working directory
     go get -d code.cloudfoundry.org/fissile || true      # Download sources
-    pushd $GOPATH/src/code.cloudfoundry.org/fissile
+    pushd $GOPATH/src/code.cloudfoundry.org/fissile || exit
     make tools                              # install required tools; only needed first time
     make docker-deps                        # pull docker images required to build
     make build
@@ -29,7 +29,7 @@ fi
 info "Building bosh release"
 # Keep fissile generated cache inside our build dir
 export HOME=$PWD
-pushd ${FISSILE_OPT_BOSH_RELEASE}
+pushd ${FISSILE_OPT_BOSH_RELEASE} || exit
 
 GIT_COMMIT=$(git rev-parse --short HEAD)
 BOSH_REL="${FISSILE_OPT_RELEASE_NAME}"-dev-"${GIT_COMMIT}".tgz

--- a/modules/extra/fissile.sh
+++ b/modules/extra/fissile.sh
@@ -20,8 +20,8 @@ if [ ! -e "bin/fissile" ]; then
     make tools                              # install required tools; only needed first time
     make docker-deps                        # pull docker images required to build
     make build
-    popd
-    popd
+    popd || exit
+    popd || exit
     mv $GOPATH/src/code.cloudfoundry.org/fissile/build/linux-amd64/fissile bin/
     rm -rf buildfissile
 fi
@@ -43,7 +43,7 @@ docker run --rm -ti -v ${FISSILE_OPT_BOSH_RELEASE}:/bosh-release \
             /bin/bash -c "cd /bosh-release && bosh create-release --force --tarball=${BOSH_REL} --name=${FISSILE_OPT_RELEASE_NAME} --version=${FISSILE_OPT_RELEASE_VERSION} && chmod 777 ${BOSH_REL}"
 
 #git submodule sync --recursive && git submodule update --init --recursive && git submodule foreach --recursive "git checkout . && git reset --hard && git clean -dffx"
-popd
+popd || exit
 
 mv ${FISSILE_OPT_BOSH_RELEASE}/"${BOSH_REL}" ./
 SHA=$(sha1sum ${PWD}/${BOSH_REL} | cut -d' ' -f1)

--- a/modules/extra/fissile.sh
+++ b/modules/extra/fissile.sh
@@ -6,8 +6,6 @@
 
 supported_backend "kind"
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 if [ ! -e "bin/fissile" ]; then
     # Takes a dev bosh release checkout and make it an image. Upload it also to the kind cluster
     info "Building fissile from develop"

--- a/modules/extra/ingress_forward.sh
+++ b/modules/extra/ingress_forward.sh
@@ -3,5 +3,5 @@
 . ../../include/common.sh
 . .envrc
 
-exec kubectl port-forward -n default pod/socksproxy "${KUBEPROXY_PORT}":8000
 info "Forwarding.. CTRL^C when you are done!"
+exec kubectl port-forward -n default pod/socksproxy "${KUBEPROXY_PORT}":8000

--- a/modules/extra/task.sh
+++ b/modules/extra/task.sh
@@ -21,6 +21,6 @@ info "Running $TASK_SCRIPT in /catapult/build$CLUSTER_NAME inside the task pod (
 info "@@@@@@@@@@@@@@"
 info
 
-kubectl exec -ti task -n catapult -- /bin/bash -l -c "pushd build$CLUSTER_NAME && source .envrc && popd && /catapult/build$CLUSTER_NAME/$(basename $TASK_SCRIPT)"
+kubectl exec -ti task -n catapult -- /bin/bash -l -c "( pushd build$CLUSTER_NAME || exit ) && source .envrc && popd && /catapult/build$CLUSTER_NAME/$(basename $TASK_SCRIPT)"
 status=$?
 exit $status

--- a/modules/extra/task.sh
+++ b/modules/extra/task.sh
@@ -21,6 +21,6 @@ info "Running $TASK_SCRIPT in /catapult/build$CLUSTER_NAME inside the task pod (
 info "@@@@@@@@@@@@@@"
 info
 
-kubectl exec -ti task -n catapult -- /bin/bash -l -c "( pushd build$CLUSTER_NAME || exit ) && source .envrc && popd && /catapult/build$CLUSTER_NAME/$(basename $TASK_SCRIPT)"
+kubectl exec -ti task -n catapult -- /bin/bash -l -c "pushd build$CLUSTER_NAME || exit && source .envrc && popd && /catapult/build$CLUSTER_NAME/$(basename $TASK_SCRIPT)"
 status=$?
 exit $status

--- a/modules/extra/terminal.sh
+++ b/modules/extra/terminal.sh
@@ -14,7 +14,7 @@ kubectl cp $ROOT_DIR/build$CLUSTER_NAME catapult/task:/catapult/
 kubectl exec -ti -n catapult task -- /bin/bash -c "CLUSTER_NAME=$CLUSTER_NAME make buildir scf-login" || true
 kubectl exec -ti -n catapult task -- /bin/bash -c "chsh root -s /bin/zsh" || true
 
-echo "pushd /catapult/build$CLUSTER_NAME ; source .envrc ; popd || true" > .zshrc
+echo "pushd /catapult/build$CLUSTER_NAME || exit ; source .envrc ; popd || exit" > .zshrc
 # Inject a sane zshrc!
 cat <<'EOF' >> .zshrc
 export TERM=xterm

--- a/modules/extra/terminal.sh
+++ b/modules/extra/terminal.sh
@@ -14,7 +14,7 @@ kubectl cp $ROOT_DIR/build$CLUSTER_NAME catapult/task:/catapult/
 kubectl exec -ti -n catapult task -- /bin/bash -c "CLUSTER_NAME=$CLUSTER_NAME make buildir scf-login" || true
 kubectl exec -ti -n catapult task -- /bin/bash -c "chsh root -s /bin/zsh" || true
 
-echo "pushd /catapult/build$CLUSTER_NAME ; source .envrc ; popd" > .zshrc
+echo "pushd /catapult/build$CLUSTER_NAME ; source .envrc ; popd || true" > .zshrc
 # Inject a sane zshrc!
 cat <<'EOF' >> .zshrc
 export TERM=xterm

--- a/modules/extra/top.sh
+++ b/modules/extra/top.sh
@@ -5,7 +5,7 @@
 . .envrc
 
 if [ ! -e "bin/k9s" ]; then
-    wget https://github.com/derailed/k9s/releases/download/"${K9S_VERSION}"/k9s_"${K9S_VERSION}"_"${K9S_OS_TYPE}.tar.gz" -O k9s.tar.gz
+    wget https://github.com/derailed/k9s/releases/download/"${K9S_VERSION}"/k9s_"${K9S_VERSION}"_"${K9S_OS_TYPE}".tar.gz -O k9s.tar.gz
     tar -xvf k9s.tar.gz -C bin/
     rm -rfv k9s.tar.gz
     chmod +x bin/k9s

--- a/modules/extra/web.sh
+++ b/modules/extra/web.sh
@@ -6,17 +6,17 @@
 info "Building wtty image"
 pushd "$ROOT_DIR"/kube/catapult-wtty
     docker build -t catapult-wtty .
-popd
+popd || exit
 
 info "Building sync image"
 pushd "$ROOT_DIR"/kube/catapult-sync
     docker build --build-arg=EKCP_HOST=$EKCP_HOST -t catapult-sync .
-popd
+popd || exit
 
 info "Building redirector image"
 pushd "$ROOT_DIR"/kube/catapult-web
     docker build -t catapult-web .
-popd
+popd || exit
 
 docker rm --force catapult-sync || true
 docker rm --force catapult-web || true

--- a/modules/extra/web.sh
+++ b/modules/extra/web.sh
@@ -21,7 +21,7 @@ popd || exit
 docker rm --force catapult-sync || true
 docker rm --force catapult-web || true
 
-docker rm --force $(docker ps -f name=catapult-wtty --format={{.Names}}) || true
+docker rm --force "$(docker ps -f name=catapult-wtty --format=\{\{.Names\}\})" || true
 
 docker run -d --restart=always -v /var/run/docker.sock:/var/run/docker.sock --name catapult-sync catapult-sync
 docker run -e TMPDIR=$TMPDIR -v $TMPDIR:$TMPDIR -e EKCP_HOST="$EKCP_HOST" -d -p 7060:8080 --restart=always -v /var/run/docker.sock:/var/run/docker.sock --name catapult-web catapult-web

--- a/modules/extra/web.sh
+++ b/modules/extra/web.sh
@@ -4,17 +4,17 @@
 . ../../include/common.sh
 
 info "Building wtty image"
-pushd "$ROOT_DIR"/kube/catapult-wtty
+pushd "$ROOT_DIR"/kube/catapult-wtty || exit
     docker build -t catapult-wtty .
 popd || exit
 
 info "Building sync image"
-pushd "$ROOT_DIR"/kube/catapult-sync
+pushd "$ROOT_DIR"/kube/catapult-sync || exit
     docker build --build-arg=EKCP_HOST=$EKCP_HOST -t catapult-sync .
 popd || exit
 
 info "Building redirector image"
-pushd "$ROOT_DIR"/kube/catapult-web
+pushd "$ROOT_DIR"/kube/catapult-web || exit
     docker build -t catapult-web .
 popd || exit
 

--- a/modules/scf/brats_setup.sh
+++ b/modules/scf/brats_setup.sh
@@ -6,7 +6,7 @@
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
-aux_external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
+aux_external_ips=("$(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address')")
 external_ips+="\"$public_ip\""
 for (( i=0; i < ${#aux_external_ips[@]}; i++ )); do
     external_ips+=", \"${aux_external_ips[$i]}\""

--- a/modules/scf/build.sh
+++ b/modules/scf/build.sh
@@ -10,9 +10,9 @@ if [ -z "$SCF_LOCAL" ]; then
     git submodule sync --recursive && \
     git submodule update --init --recursive && \
     git submodule foreach --recursive "git checkout . && git reset --hard && git clean -dffx"
-    pushd scf
+    pushd scf || exit
 else
-    pushd "$SCF_LOCAL"
+    pushd "$SCF_LOCAL" || exit
 fi
 
 GIT_HEAD=$(git log --pretty=format:'%h' -n 1)

--- a/modules/scf/build.sh
+++ b/modules/scf/build.sh
@@ -31,7 +31,7 @@ else
     unzip -o ./*.zip
     SCF_CHART=scf-"$GIT_HEAD"
 fi
-popd
+popd || exit
 
 # save SCF_CHART on cap-values configmap
 kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -41,7 +41,7 @@ if [ -n "$SCF_HELM_VERSION" ]; then
     mkdir -p charts/helm
     tar xvf cf-*.tgz -C charts/helm
     tar xvf uaa-*.tgz -C charts/helm
-    pushd charts
+    pushd charts || exit
         VERSION=$(yq r helm/cf/Chart.yaml version)
         API_VERSION=$(yq r helm/cf/Chart.yaml apiVersion)
 

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -62,7 +62,7 @@ if [ -n "$SCF_HELM_VERSION" ]; then
         tar cvzf ../scf-sle-${API_VERSION}.tgz *
         zip -r9 ../scf-sle-${API_VERSION}.zip -- *
         export SCF_CHART=$PWD/../scf-sle-${API_VERSION}.zip
-    popd
+    popd || exit
 fi
 
 rm -rf scf_chart_url || true

--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -6,9 +6,11 @@
 
 
 info "Generating SCF config values"
-if [ "${DEFAULT_STACK}" = "from_chart" ]; then
-    DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
-    export DEFAULT_STACK
+if [ "$SCF_OPERATOR" != true ]; then
+    if [ "${DEFAULT_STACK}" = "from_chart" ]; then
+        DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+        export DEFAULT_STACK
+    fi
 fi
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')

--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -7,7 +7,8 @@
 
 info "Generating SCF config values"
 if [ "${DEFAULT_STACK}" = "from_chart" ]; then
-    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    export DEFAULT_STACK
 fi
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')

--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -13,7 +13,7 @@ fi
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
-aux_external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
+aux_external_ips=("$(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address')")
 external_ips+="\"$public_ip\""
 for (( i=0; i < ${#aux_external_ips[@]}; i++ )); do
 external_ips+=", \"${aux_external_ips[$i]}\""

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -52,8 +52,6 @@ elif [ "${SCF_OPERATOR}" == "true" ]; then
         fi
     fi
 
-    domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
-
     info "Installing cf-operator"
     kubectl create namespace cf-operator || true
 

--- a/modules/scf/stemcell_build.sh
+++ b/modules/scf/stemcell_build.sh
@@ -7,7 +7,7 @@
 [ ! -d "bosh-linux-stemcell-builder" ] && \
     git clone https://github.com/SUSE/bosh-linux-stemcell-builder.git
 
-pushd bosh-linux-stemcell-builder
+pushd bosh-linux-stemcell-builder || exit
     git checkout devel
     make all
 popd || exit

--- a/modules/scf/stemcell_build.sh
+++ b/modules/scf/stemcell_build.sh
@@ -10,4 +10,4 @@
 pushd bosh-linux-stemcell-builder
     git checkout devel
     make all
-popd
+popd || exit

--- a/modules/tests/autoscaler.sh
+++ b/modules/tests/autoscaler.sh
@@ -11,7 +11,7 @@ cf install-plugin -r CF-Community app-autoscaler-plugin -f
 # clone sample app
 SAMPLE_FOLDER=autoscaled-app
 [ ! -d "$SAMPLE_FOLDER" ] && git clone --recurse-submodules "$SAMPLE_APP_REPO" "$SAMPLE_FOLDER"
-pushd "$SAMPLE_FOLDER"
+pushd "$SAMPLE_FOLDER" || exit
 if [ -n "$EKCP_PROXY" ]; then
     export https_proxy=socks5://127.0.0.1:${KUBEPROXY_PORT}
 fi

--- a/modules/tests/cats.sh
+++ b/modules/tests/cats.sh
@@ -7,7 +7,8 @@
 DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 
 if [ "${DEFAULT_STACK}" = "from_chart" ]; then
-    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    export DEFAULT_STACK
 fi
 
 [ ! -d "cf-acceptance-tests" ] && git clone https://github.com/cloudfoundry/cf-acceptance-tests

--- a/modules/tests/cats.sh
+++ b/modules/tests/cats.sh
@@ -12,7 +12,7 @@ fi
 
 [ ! -d "cf-acceptance-tests" ] && git clone https://github.com/cloudfoundry/cf-acceptance-tests
 
-pushd cf-acceptance-tests
+pushd cf-acceptance-tests || exit
 cat > config.json <<EOF
 {
   "api"                             : "api.${DOMAIN}",
@@ -73,7 +73,7 @@ rm -rf "$GOPATH"/src/*
 
 mkdir -p "$GOPATH"/src/github.com/cloudfoundry
 [ ! -e "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests ] && ln -s "$PWD" "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests
-pushd "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests
+pushd "$GOPATH"/src/github.com/cloudfoundry/cf-acceptance-tests || exit
 go get github.com/onsi/ginkgo/ginkgo
 go install github.com/onsi/ginkgo/ginkgo
 if [ -n "$EKCP_PROXY" ]; then

--- a/modules/tests/cats_scf.sh
+++ b/modules/tests/cats_scf.sh
@@ -51,9 +51,9 @@ SECRETS_FILE=${SECRETS_FILE:-"$ROOT_DIR"/../cloudfoundry/secure/concourse-secret
 # Create secret for the imagePullSecrets we renamed in the scf images:
 kubectl create secret docker-registry tests-registry-credentials \
         --namespace scf \
-        --docker-server=$(grep "docker-internal-registry:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- ) \
-        --docker-username=$(grep "docker-internal-username:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- ) \
-        --docker-password="$(grep "docker-internal-password:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- )"
+        --docker-server="$(grep "docker-internal-registry:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )" \
+        --docker-username="$(grep "docker-internal-username:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )" \
+        --docker-password="$(grep "docker-internal-password:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )"
 
 image=$(gawk '$1 == "image:" { gsub(/"/, "", $2); print $2 }' kube/cf/bosh-task/acceptance-tests.yaml)
 kubectl run \

--- a/modules/tests/eirini_persi.sh
+++ b/modules/tests/eirini_persi.sh
@@ -6,7 +6,7 @@
 # Don't touch original copy
 cp -rfv ../contrib/samples/eirini-persi-test ./
 
-pushd eirini-persi-test
+pushd eirini-persi-test || exit
 
 go build -o persi-test main.go
 

--- a/modules/tests/kubecats.sh
+++ b/modules/tests/kubecats.sh
@@ -5,7 +5,8 @@
 . .envrc
 
 
-export DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+export DOMAIN
 DEPLOYED_CHART=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["chart"]')
 
 info
@@ -18,7 +19,8 @@ kubectl create namespace catapult || true
 kubectl delete pod cats -n catapult || true
 
 if [ "${DEFAULT_STACK}" = "from_chart" ]; then
-    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    export DEFAULT_STACK
 fi
 
 export CATS_REPO=$CATS_REPO

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -45,7 +45,7 @@ pushd "$KUBECF_CHECKOUT"
         pod_name="$(cf_acceptance_tests_pod_name)"
         container_name="acceptance-tests-acceptance-tests"
     fi
-popd
+popd || exit
 
 wait_for_tests_pod "$pod_name" "$container_name" || {
 >&2 err "Timed out waiting for the tests pod"

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -26,7 +26,7 @@ wait_for_tests_pod() {
 kubectl delete jobs -n "${KUBECF_NAMESPACE}"  --all || true
 
 timeout="300"
-pushd "$KUBECF_CHECKOUT"
+pushd "$KUBECF_CHECKOUT" || exit
     # FIXME: See how to pass those options to bazel commands - we make it not to fail to be idempotent but we edit user files on git checkout (BAD!)
     sed -i 's/namespace = "kubecf"/namespace = "'"$KUBECF_NAMESPACE"'"/' def.bzl || true
     sed -i 's/deployment_name = "kubecf"/deployment_name =  "'"$KUBECF_DEPLOYMENT_NAME"'"/' def.bzl || true

--- a/modules/tests/kubesmokes.sh
+++ b/modules/tests/kubesmokes.sh
@@ -5,7 +5,8 @@
 . .envrc
 
 
-export DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+export DOMAIN
 DEPLOYED_CHART=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["chart"]')
 
 info

--- a/modules/tests/sample-ticking.sh
+++ b/modules/tests/sample-ticking.sh
@@ -6,7 +6,7 @@
 # Don't touch original copy
 cp -rfv ../contrib/samples/ticking_app ./
 
-pushd ticking_app
+pushd ticking_app || exit
 
 go build -o log_producing_app main.go
 

--- a/modules/tests/sample.sh
+++ b/modules/tests/sample.sh
@@ -8,7 +8,7 @@ SAMPLE_FOLDER=$(basename "$SAMPLE_APP_REPO")
 
 [ ! -d "$SAMPLE_FOLDER" ] && git clone --recurse-submodules "$SAMPLE_APP_REPO" "$SAMPLE_FOLDER"
 
-pushd "$SAMPLE_FOLDER"
+pushd "$SAMPLE_FOLDER" || exit
 
 if [ -n "$EKCP_PROXY" ]; then
     export https_proxy=socks5://127.0.0.1:${KUBEPROXY_PORT}

--- a/modules/tests/smoke.sh
+++ b/modules/tests/smoke.sh
@@ -7,7 +7,7 @@ DOMAIN=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data[
 
 [ ! -d "cf-smoke-tests" ] && git clone https://github.com/cloudfoundry/cf-smoke-tests
 
-pushd cf-smoke-tests
+pushd cf-smoke-tests || exit
 cat > config.json <<EOF
 {
   "suite_name"                      : "CF_SMOKE_TESTS",
@@ -37,7 +37,7 @@ rm -rf "$GOPATH"/src/*
 
 mkdir -p "$GOPATH"/src/github.com/cloudfoundry
 [ ! -e "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests ] && ln -s "$PWD" "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests
-pushd "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests
+pushd "$GOPATH"/src/github.com/cloudfoundry/cf-smoke-tests || exit
 
 
 if [ -n "$EKCP_PROXY" ]; then

--- a/modules/tests/smoke_scf.sh
+++ b/modules/tests/smoke_scf.sh
@@ -51,9 +51,9 @@ SECRETS_FILE=${SECRETS_FILE:-"$ROOT_DIR"/../cloudfoundry/secure/concourse-secret
 # Create secret for the imagePullSecrets we renamed in the scf images:
 kubectl create secret docker-registry tests-registry-credentials \
         --namespace scf \
-        --docker-server=$(grep "docker-internal-registry:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- ) \
-        --docker-username=$(grep "docker-internal-username:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- ) \
-        --docker-password="$(grep "docker-internal-password:" <<< $(gpg --decrypt --batch "$SECRETS_FILE") | cut -d ' ' -f 3- )"
+        --docker-server="$(grep "docker-internal-registry:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )" \
+        --docker-username="$(grep "docker-internal-username:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )" \
+        --docker-password="$(grep "docker-internal-password:" <<< "$(gpg --decrypt --batch "$SECRETS_FILE")" | cut -d ' ' -f 3- )"
 
 image=$(gawk '$1 == "image:" { gsub(/"/, "", $2); print $2 }' kube/cf/bosh-task/smoke-tests.yaml)
 kubectl run \

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -8,12 +8,14 @@ export ENABLE_EIRINI=false
 [ ! -d "shunit2" ] && git clone https://github.com/kward/shunit2.git
 
 setUp() {
-    export ROOT_DIR="$(git rev-parse --show-toplevel)"
+    ROOT_DIR="$(git rev-parse --show-toplevel)"
+    export ROOT_DIR
     pushd "$ROOT_DIR" || exit
 }
 
 tearDown() {
-    export ROOT_DIR="$(git rev-parse --show-toplevel)"
+    ROOT_DIR="$(git rev-parse --show-toplevel)"
+    export ROOT_DIR
     pushd "$ROOT_DIR" || exit
     rm -rf buildtest
 }

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -25,7 +25,7 @@ tearDown() {
 #   deployst=$?
 #   pushd buildtest
 #   source .envrc
-#   popd
+#   popd || exit
 #   assertTrue 'create buildir' "[ -d 'buildtest' ]"
 #   PODS="$(kubectl get pods -n scf)"
 #   SVCS="$(kubectl get svc -n scf)"

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -51,6 +51,9 @@ testKind() {
     assertEquals 'deploys successfully' "$deployst" "0"
     make scf-chart
     assertTrue 'helm folder is present' "[ -d 'buildtest/helm' ]"
+    AUTOSCALER=true make scf-gen-config
+    VALUES_FILE=$(cat $ROOT_DIR/buildtest/scf-config-values.yaml)
+    assertContains 'generates correctly AUTOSCALER' "$VALUES_FILE" "autoscaler: true"
     make module-extra-ingress
     deployst=$?
     assertEquals 'deploys ingress successfully' "$deployst" "0"

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -9,12 +9,12 @@ export ENABLE_EIRINI=false
 
 setUp() {
     export ROOT_DIR="$(git rev-parse --show-toplevel)"
-    pushd "$ROOT_DIR"
+    pushd "$ROOT_DIR" || exit
 }
 
 tearDown() {
     export ROOT_DIR="$(git rev-parse --show-toplevel)"
-    pushd "$ROOT_DIR"
+    pushd "$ROOT_DIR" || exit
     rm -rf buildtest
 }
 
@@ -23,7 +23,7 @@ tearDown() {
 #   rm -rf buildtest
 #   make scf-deploy
 #   deployst=$?
-#   pushd buildtest
+#   pushd buildtest || exit
 #   source .envrc
 #   popd || exit
 #   assertTrue 'create buildir' "[ -d 'buildtest' ]"

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -7,7 +7,8 @@ BUILDDIR_REGEXP="^$ROOT_DIR/build"
 
 info "Linting shell scripts" && debug_mode
 SH_FILES=$(find "$ROOT_DIR" -type f -name '*.sh' -o -name '*.ksh' -o -name '*.bash' | grep -v "shunit2" | grep -v "$BUILDDIR_REGEXP" )
-shellcheck --severity=warning $SH_FILES || retcode=1
+# SC1090 we are building paths with $BACKEND
+shellcheck --severity=warning -e SC1090 $SH_FILES || retcode=1
 
 info "Linting yamls" && debug_mode
 YML_FILES=$(find "$ROOT_DIR" -type f -name '*.yaml' -o -name '*.yml' | grep -v "shunit2" | grep -v "$BUILDDIR_REGEXP")

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -7,7 +7,7 @@ BUILDDIR_REGEXP="^$ROOT_DIR/build"
 
 info "Linting shell scripts" && debug_mode
 SH_FILES=$(find "$ROOT_DIR" -type f -name '*.sh' -o -name '*.ksh' -o -name '*.bash' | grep -v "shunit2" | grep -v "$BUILDDIR_REGEXP" )
-shellcheck --severity=error $SH_FILES || retcode=1
+shellcheck --severity=warning $SH_FILES || retcode=1
 
 info "Linting yamls" && debug_mode
 YML_FILES=$(find "$ROOT_DIR" -type f -name '*.yaml' -o -name '*.yml' | grep -v "shunit2" | grep -v "$BUILDDIR_REGEXP")

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -52,7 +52,7 @@ testConfig() {
   assertContains 'generates correctly AUTOSCALER' "$VALUES_FILE" "autoscaler: false"
 
   AUTOSCALER=true make scf-gen-config
-  VALUES_FILE="$(cat $ROOT_DIR/buildtest/scf-config-values.yaml)"
+  VALUES_FILE=$(cat $ROOT_DIR/buildtest/scf-config-values.yaml)
   assertContains 'generates correctly AUTOSCALER' "$VALUES_FILE" "autoscaler: true"
 }
 

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -8,12 +8,12 @@ setUp() {
     export PATH=$ROOT_DIR/tests/mocks:"$PATH"
     export CLUSTER_NAME=test
     export ROOT_DIR="$(git rev-parse --show-toplevel)"
-    pushd "$ROOT_DIR"
+    pushd "$ROOT_DIR" || exit
 }
 
 tearDown() {
     export ROOT_DIR="$(git rev-parse --show-toplevel)"
-    pushd "$ROOT_DIR"
+    pushd "$ROOT_DIR" || exit
     rm -rf buildtest
 }
 

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -7,12 +7,14 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 setUp() {
     export PATH=$ROOT_DIR/tests/mocks:"$PATH"
     export CLUSTER_NAME=test
-    export ROOT_DIR="$(git rev-parse --show-toplevel)"
+    ROOT_DIR="$(git rev-parse --show-toplevel)"
+    export ROOT_DIR
     pushd "$ROOT_DIR" || exit
 }
 
 tearDown() {
-    export ROOT_DIR="$(git rev-parse --show-toplevel)"
+    ROOT_DIR="$(git rev-parse --show-toplevel)"
+    export ROOT_DIR
     pushd "$ROOT_DIR" || exit
     rm -rf buildtest
 }

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -50,10 +50,6 @@ testConfig() {
   assertContains 'generates correctly STORAGECLASS (2)' "$VALUES_FILE" "persistent: \"our-storage\""
   assertContains 'generates correctly STORAGECLASS (3)' "$VALUES_FILE" "shared: \"our-storage\""
   assertContains 'generates correctly AUTOSCALER' "$VALUES_FILE" "autoscaler: false"
-
-  AUTOSCALER=true make scf-gen-config
-  VALUES_FILE=$(cat $ROOT_DIR/buildtest/scf-config-values.yaml)
-  assertContains 'generates correctly AUTOSCALER' "$VALUES_FILE" "autoscaler: true"
 }
 
 # Tests backend switch


### PR DESCRIPTION
This PR increases `shellcheck to --severity=warning`, refactors and makes notes for false potisitives.
Increasing severity actually found a bunch of bugs, fixed them as part of it.

unit & integration-tests are passing, deployed kubecf successfully too.

God bless emacs recursive edit..
