### PR TITLE
Wait for cf-operator resources to be available before start KubeCF deployment

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -281,3 +281,8 @@ function helm_ls {
         helm ls
     fi
 }
+
+function wait_for {
+    info "Waiting for $1"
+    n=0; until ((n >= 60)); do eval "$1" && break; n=$((n + 1)); sleep 1; done; ((n < 60))
+}

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -64,7 +64,15 @@ elif [ "${SCF_OPERATOR}" == "true" ]; then
     --set "global.operator.watchNamespace=scf"
 
     wait_ns cf-operator
-    sleep 10
+
+    info "Wait for cf-operator to be ready"
+    wait_for "kubectl get endpoints -n cf-operator cf-operator-webhook -o name"
+    wait_for "kubectl get crd quarksstatefulsets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
+    sleep 10 # Give extra time for operator to avoid flakyness
+    ok "cf-operator ready"
 
     # SCFv3 Doesn't support to setup a cluster password yet, doing it manually.
     kubectl create secret generic -n scf susecf-scf.var-cf-admin-password --from-literal=password="${CLUSTER_PASSWORD}"


### PR DESCRIPTION
This should help with https://github.com/cloudfoundry-incubator/kubecf/issues/558 . It's hard to reproduce, and I couldn't locally, but waiting for the operator crd to be in place seems safer than start deploying right away. 