### PR TITLE
Test cf-operator before installing KubeCF

### DIFF
--- a/kube/cf-operator/boshdeployment.yaml
+++ b/kube/cf-operator/boshdeployment.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-scale
+data:
+  ops: |
+    - type: replace
+      path: /instance_groups/name=nats?/instances
+      value: 2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-manifest
+data:
+  manifest: |
+    ---
+    name: nats-deployment
+    releases:
+    - name: nats
+      version: "26"
+      url: docker.io/cfcontainerization
+      stemcell:
+        os: opensuse-42.3
+        version: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+    instance_groups:
+    - name: nats
+      instances: 1
+      jobs:
+      - name: nats
+        release: nats
+        properties:
+          nats:
+            user: admin
+            password: ((nats_password))
+          quarks:
+            ports:
+            - name: "nats"
+              protocol: "TCP"
+              internal: 4222
+            - name: "nats-routes"
+              protocol: TCP
+              internal: 4223
+    variables:
+    - name: nats_password
+      type: password
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: BOSHDeployment
+metadata:
+  name: nats-deployment
+spec:
+  manifest:
+    name: nats-manifest
+    type: configmap
+  ops:
+  - name: ops-scale
+    type: configmap

--- a/kube/cf-operator/password.yaml
+++ b/kube/cf-operator/password.yaml
@@ -1,0 +1,7 @@
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: generate-password
+spec:
+  type: password
+  secretName: gen-secret1

--- a/kube/cf-operator/qstatefulset_tolerations.yaml
+++ b/kube/cf-operator/qstatefulset_tolerations.yaml
@@ -1,0 +1,27 @@
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksStatefulSet
+metadata:
+  name: example-quarks-statefulset
+spec:
+  template:
+    metadata:
+      labels:
+        app: example-statefulset
+    spec:
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: example-statefulset
+        spec:
+          containers:
+          - name: busybox
+            image: busybox
+            command:
+            - sleep
+            - "3600"
+          tolerations:
+          - key: "key"
+            operator: "Equal"
+            value: "value"
+            effect: "NoSchedule"

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -71,7 +71,14 @@ elif [ "${SCF_OPERATOR}" == "true" ]; then
     wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
     wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
     wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
-    sleep 10 # Give extra time for operator to avoid flakyness
+    info "Test CRDs are ready"
+    #wait_for "kubectl apply -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl apply -f ../kube/cf-operator/password.yaml --namespace=scf"
+    wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
+    wait_ns scf
+    #wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
+    wait_for "kubectl delete -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
     ok "cf-operator ready"
 
     # SCFv3 Doesn't support to setup a cluster password yet, doing it manually.


### PR DESCRIPTION
Try to install QuarksSecret and QuarksSts before starting
to deploy KubeCF. 
It's far from optimal, we attempt to install resources that should be handled by the operator before deploying KubeCF and then we remove them.

Should probably fix https://github.com/cloudfoundry-incubator/kubecf/issues/558
 
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>