### PR TITLE
kubecf-test: compatibility with cf-operator 4

### DIFF
--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -1,82 +1,95 @@
 #!/bin/bash
 
+# This script runs a test suite on kubecf
+
 . ./defaults.sh
 . ../../include/common.sh
 . .envrc
 
-smoke_tests_pod_name() {
-  kubectl get pods --namespace "${KUBECF_NAMESPACE}" --output name 2> /dev/null | grep "smoke-tests"
+# Get the name of the resource matching the given pattern
+get_resource_name() {
+  local resource_type="${1}"
+  local pattern="${2}"
+  kubectl get "${resource_type}" --namespace "${KUBECF_NAMESPACE}" --output name \
+    2> /dev/null | grep "${pattern}"
 }
 
-sync_integration_tests_pod_name() {
-  kubectl get pods --namespace "${KUBECF_NAMESPACE}" --output name 2> /dev/null | grep "sync-integration-tests"
+# Run a command repeatedly until it returns success, at one second interval.
+# The first argument is the number of tries; the rest are the command to run.
+wait_for_timeout() {
+  local timeout="${1}"
+  shift
+  until "${@}" || [[ "${timeout}" == 0 ]]; do
+    sleep 1
+    timeout=$((timeout - 1))
+  done
 }
 
-cf_acceptance_tests_pod_name() {
-  kubectl get pods --namespace "${KUBECF_NAMESPACE}" --output name 2> /dev/null | grep "acceptance-tests"
+# Start the given test suite, and wait for the pod to exist.
+trigger_test_suite() {
+  local qjob suite_name="${1}"
+  qjob="$(get_resource_name qjob "${suite_name}")"
+  kubectl patch "${qjob}" --namespace "${KUBECF_NAMESPACE}" --type merge --patch \
+    '{ spec: { trigger: { strategy: now } } }'
+  info "waiting for the ${suite_name} pod to start..."
+  wait_for_timeout 300 get_resource_name pod "${suite_name}"
+  [[ "${timeout}" != 0 ]]
 }
 
-brain_tests_pod_name() {
-  kubectl get pods --namespace "${KUBECF_NAMESPACE}" --output name 2> /dev/null | grep "brain-tests"
+# Check if the given pod (with a given container) has either started running or
+# terminated (in case the run time is very short).
+is_pod_started() {
+  local pod_name="${1}" container_name="${2}"
+  local state jsonpath result
+  for state in running terminated ; do
+    jsonpath="{.status.containerStatuses[?(@.name == \"$container_name\")].state.${state}}"
+    result="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}" 2> /dev/null || true)"
+    if [[ -n "${result}" ]] ; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Wait for tests pod to start.
 wait_for_tests_pod() {
-  local podname=$1
-  local containername=$2
-  local timeout="300"
-  info "Waiting for container $containername in $podname"
-  until [[ "$(kubectl get "${podname}" --namespace "${KUBECF_NAMESPACE}" --output jsonpath='{.status.containerStatuses[?(@.name == "'"$containername"'")].state.running}' 2> /dev/null)" != "" ]] || [[ "$(kubectl get "${podname}" --namespace "${KUBECF_NAMESPACE}" --output jsonpath='{.status.containerStatuses[?(@.name == "'"$containername"'")].state.terminated}' 2> /dev/null)" != "" ]]  || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$((timeout - 1)); done
-  if [[ "${timeout}" == 0 ]]; then return 1; fi
-  return 0
+  local pod_name="${1}" container_name="${2}"
+  info "Waiting for container $container_name in $pod_name"
+  wait_for_timeout 300 is_pod_started "${pod_name}" "${container_name}"
 }
 
 # Delete any pending job
 kubectl delete jobs -n "${KUBECF_NAMESPACE}"  --all --wait || true
 
 timeout="300"
-if [ "${KUBECF_TEST_SUITE}" == "smokes" ]; then
-    kubectl patch qjob "${KUBECF_DEPLOYMENT_NAME}"-smoke-tests --namespace "${KUBECF_NAMESPACE}" --type merge --patch 'spec:
-      trigger:
-          strategy: now'
-    info "Waiting for the smoke-tests pod to start..."
-    until smoke_tests_pod_name || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$((timeout - 1)); done
-    if [[ "${timeout}" == 0 ]]; then return 1; fi
-    pod_name="$(smoke_tests_pod_name)"
-    container_name="smoke-tests-smoke-tests"
-elif [ "${KUBECF_TEST_SUITE}" == "sits" ]; then
-    kubectl patch qjob "${KUBECF_DEPLOYMENT_NAME}"-sync-integration-tests --namespace "${KUBECF_NAMESPACE}" --type merge --patch 'spec:
-      trigger:
-          strategy: now'
-    info "Waiting for the sync-integration-tests pod to start..."
-    until sync_integration_tests_pod_name || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$((timeout - 1)); done
-    if [[ "${timeout}" == 0 ]]; then return 1; fi
-    pod_name="$(sync_integration_tests_pod_name)"
-    container_name="sync-integration-tests-sync-integration-tests"
-elif [ "${KUBECF_TEST_SUITE}" == "brain" ]; then
-    kubectl patch qjob "${KUBECF_DEPLOYMENT_NAME}"-brain-tests --namespace "${KUBECF_NAMESPACE}" --type merge --patch 'spec:
-      trigger:
-          strategy: now'
-    info "Waiting for the acceptance-tests-brain pod to start..."
-    until brain_tests_pod_name || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$((timeout - 1)); done
-    if [[ "${timeout}" == 0 ]]; then return 1; fi
-    pod_name="$(brain_tests_pod_name)"
-    container_name="acceptance-tests-brain-acceptance-tests-brain"
-else
-    kubectl patch qjob "${KUBECF_DEPLOYMENT_NAME}"-acceptance-tests --namespace "${KUBECF_NAMESPACE}" --type merge --patch 'spec:
-      trigger:
-          strategy: now'
-    info "Waiting for the acceptance-tests pod to start..."
-    until cf_acceptance_tests_pod_name || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$((timeout - 1)); done
-    if [[ "${timeout}" == 0 ]]; then return 1; fi
-    pod_name="$(cf_acceptance_tests_pod_name)"
-    container_name="acceptance-tests-acceptance-tests"
-fi
 
-wait_for_tests_pod "$pod_name" "$container_name" || {
->&2 err "Timed out waiting for the tests pod"
-exit 1
-}
+case "${KUBECF_TEST_SUITE}" in
+  smokes)
+    trigger_test_suite smoke-tests
+    pod_name="$(get_resource_name pod smoke-tests)"
+    container_name="smoke-tests-smoke-tests"
+    ;;
+  sits)
+    trigger_test_suite sync-integration-tests
+    pod_name="$(get_resource_name pod sync-integration-tests)"
+    container_name="sync-integration-tests-sync-integration-tests"
+    ;;
+  brain)
+    trigger_test_suite brain-tests
+    pod_name="$(get_resource_name pod brain-tests)"
+    container_name="acceptance-tests-brain-acceptance-tests-brain"
+    ;;
+  *)
+    trigger_test_suite acceptance-tests
+    pod_name="$(get_resource_name pod acceptance-tests)"
+    container_name="acceptance-tests-acceptance-tests"
+    ;;
+esac
+
+if ! wait_for_tests_pod "$pod_name" "$container_name" ; then
+  >&2 err "Timed out waiting for the tests pod"
+  exit 1
+fi
 
 # Follow the logs. If the tests fail, or container exits it will move on (with all logs printed)
 kubectl logs -f "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$container_name" ||:
@@ -84,9 +97,9 @@ kubectl logs -f "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$co
 # Wait for the container to terminate and then exit the script with the container's exit code.
 jsonpath='{.status.containerStatuses[?(@.name == "'"$container_name"'")].state.terminated.exitCode}'
 while true; do
-exit_code="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}")"
-if [[ -n "${exit_code}" ]]; then
-    exit "${exit_code}"
-fi
-sleep 1
+  exit_code="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}")"
+  if [[ -n "${exit_code}" ]]; then
+      exit "${exit_code}"
+  fi
+  sleep 1
 done

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -30,7 +30,7 @@ trigger_test_suite() {
   local qjob suite_name="${1}"
   qjob="$(get_resource_name qjob "${suite_name}")"
   kubectl patch "${qjob}" --namespace "${KUBECF_NAMESPACE}" --type merge --patch \
-    '{ spec: { trigger: { strategy: now } } }'
+    '{ "spec": { "trigger": { "strategy": "now" } } }'
   info "waiting for the ${suite_name} pod to start..."
   wait_for_timeout 300 get_resource_name pod "${suite_name}"
   [[ "${timeout}" != 0 ]]


### PR DESCRIPTION
The new cf-operator no longer prefixes resources (statefulsets, pods, etc.) with the deployment name.  Update the script to handle that case (while also supporting the older version).

Also, refactor the script a bit to be (hopefully) more readable, or at least have shorter lines.