### PR TITLE
Install and configure direnv inside dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM opensuse/tumbleweed:latest
-RUN zypper ref && zypper in -y git zip wget docker ruby gzip make jq curl which unzip
+RUN zypper ref && zypper in -y git zip wget docker ruby gzip make jq curl which unzip direnv
+RUN echo 'eval $(direnv hook bash)' >> ~/.bashrc
 # Extras, mostly for the terminal image (that could be split in another image)
 RUN zypper in -y vim zsh tmux glibc-locale glibc-i18ndata python ruby python3 python3-pip
 


### PR DESCRIPTION
Aids when fly hijacking, needing to source .envrc gets annoying and is error
prone.