### PR TITLE
Fix scf-clean on helm3

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -285,5 +285,6 @@ function helm_ls {
 
 function wait_for {
     info "Waiting for $1"
-    n=0; until ((n >= 60)); do eval "$1" && break; n=$((n + 1)); sleep 1; done; ((n < 60))
+    timeout=300
+    n=0; until ((n >= timeout)); do eval "$1" && break; n=$((n + 1)); sleep 1; done; ((n < timeout))
 }

--- a/include/func.sh
+++ b/include/func.sh
@@ -268,7 +268,8 @@ function helm_upgrade {
 
 function helm_delete {
     if [[ "$HELM_VERSION" == v3* ]]; then
-        helm delete "$@"
+        helm uninstall "$@"
+        wait_for "helm ls --all-namespaces 2>/dev/null | grep -qi $1"
     else
         helm delete --purge "$@"
     fi

--- a/include/func.sh
+++ b/include/func.sh
@@ -269,7 +269,8 @@ function helm_upgrade {
 function helm_delete {
     if [[ "$HELM_VERSION" == v3* ]]; then
         helm uninstall "$@"
-        wait_for "helm ls --all-namespaces 2>/dev/null | grep -qi $1"
+        # wait until there's no helm release installed
+        wait_for "! (helm ls --all-namespaces 2>/dev/null | grep -qi $1)"
     else
         helm delete --purge "$@"
     fi

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -16,10 +16,9 @@ fi
 
 if helm_ls 2>/dev/null | grep -qi susecf-scf ; then
     helm_delete susecf-scf --namespace scf
-else
-    if kubectl get namespaces 2>/dev/null | grep -qi scf ; then
-        kubectl delete --ignore-not-found namespace scf
-    fi
+fi
+if kubectl get namespaces 2>/dev/null | grep -qi scf ; then
+    kubectl delete --ignore-not-found namespace scf
 fi
 
 if kubectl get psp 2>/dev/null | grep -qi susecf-scf ; then
@@ -28,14 +27,10 @@ fi
 
 if helm_ls 2>/dev/null | grep -qi cf-operator ; then
     helm_delete cf-operator --namespace cf-operator
-else
-    if kubectl get namespaces 2>/dev/null | grep -qi cf-operator ; then
-        kubectl delete --ignore-not-found namespace cf-operator
-    fi
 fi
-
-
-
+if kubectl get namespaces 2>/dev/null | grep -qi cf-operator ; then
+    kubectl delete --ignore-not-found namespace cf-operator
+fi
 
 if [[ "$ENABLE_EIRINI" == true ]] ; then
     if kubectl get namespaces 2>/dev/null | grep -qi eirini ; then


### PR DESCRIPTION
Closes https://github.com/SUSE/catapult/issues/128

This PR cleans namespaces correctly if they exist, and augments helm_delete() using the recent wait_for() to wait until the helm release is gone.

Tested on the several deploy jobs on https://concourse.suse.dev/teams/main/pipelines/fix-scf-clean-cap-release 