### PR TITLE
Remove test jobs if successful and save test logs

### DIFF
--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -96,7 +96,7 @@ kubectl logs -f "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$co
 
 # Wait for the container to terminate and then exit the script with the container's exit code.
 jsonpath='{.status.containerStatuses[?(@.name == "'"$container_name"'")].state.terminated.exitCode}'
-exit_code="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}")"
+exit_code=""
 while [[ -z "${exit_code}" ]]; do
     exit_code="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}")"
     sleep 1

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -104,8 +104,9 @@ done
 
 # save results of tests to file
 mkdir -p artifacts
-kubectl logs "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$container_name" > \
-        artifacts/"$(date +'%Y-%m-%d-%H:%M')"_"$( echo "${pod_name}" | cut -d '/' -f 2)".log
+log="artifacts/$(date +'%Y-%m-%d-%H:%M')_${pod_name#*/}.log"
+kubectl logs "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$container_name" > "${log}"
+        
 
 if [ "${exit_code}" -ne 0 ]; then
     err "${KUBECF_TEST_SUITE} failed"

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -107,13 +107,11 @@ mkdir -p artifacts
 log="artifacts/$(date +'%Y-%m-%d-%H:%M')_${pod_name#*/}.log"
 kubectl logs "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$container_name" > "${log}"
 
-
 if [ "${exit_code}" -ne 0 ]; then
     err "${KUBECF_TEST_SUITE} failed"
     exit "${exit_code}"
-else
-    # remove job, tests were successful
-    kubectl delete jobs -n "${KUBECF_NAMESPACE}"  --all --wait || true
 fi
+# remove job, tests were successful
+kubectl delete jobs -n "${KUBECF_NAMESPACE}"  --all --wait || true
 
 ok "${KUBECF_TEST_SUITE} passed"

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -106,7 +106,7 @@ done
 mkdir -p artifacts
 log="artifacts/$(date +'%Y-%m-%d-%H:%M')_${pod_name#*/}.log"
 kubectl logs "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --container "$container_name" > "${log}"
-        
+
 
 if [ "${exit_code}" -ne 0 ]; then
     err "${KUBECF_TEST_SUITE} failed"

--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -112,7 +112,7 @@ if [ "${exit_code}" -ne 0 ]; then
     err "${KUBECF_TEST_SUITE} failed"
     exit "${exit_code}"
 else
-    # remove job, tests where successful
+    # remove job, tests were successful
     kubectl delete jobs -n "${KUBECF_NAMESPACE}"  --all --wait || true
 fi
 


### PR DESCRIPTION
If test job successful, remove job (which deletes the pod). This is needed so following `helm upgrade` (with `make scf-upgrade`) on the pipelines work as they don't redeploy and rerun the tests.

Also, whatever the outcome of the test job, save its logs onto `buildfolder/artifacts/{date}_{podname}.log`, eg:
`buildfolder/artifacts/2020-04-03-11:30_susecf-scf-smoke-tests-9edf0682ed6cf030-qh7mk.log`
