### PR TITLE
Add catapult deps and backend deps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/r
 RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
 RUN mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
 
+RUN zypper --no-recommends in -y gcc libffi-devel python3-devel libopenssl-devel
+RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
+  printf "\n\n\n\n" | python3 ./install.py && \
+  rm ./install.py
+
 RUN zypper clean --all
 
 ADD . /catapult

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
 FROM opensuse/tumbleweed:latest
 # Catapult dependencies:
-RUN zypper ref && zypper in -y git zip wget docker ruby gzip make jq python-yq curl which unzip bazel1.2 direnv
+RUN zypper ref && zypper in --no-recommends -y git zip wget docker ruby gzip make jq python-yq curl which unzip bazel1.2 direnv
 RUN echo 'eval $(direnv hook bash)' >> ~/.bashrc
 
 RUN wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_linux" -O yaml-patch
 RUN mv yaml-patch /usr/local/bin && chmod +x /usr/local/bin/yaml-patch
 
 # Extras, mostly for the terminal image (that could be split in another image)
-RUN zypper in -y vim zsh tmux glibc-locale glibc-i18ndata python ruby python3 python3-pip cf-cli
+RUN zypper in --no-recommends -y vim zsh tmux glibc-locale glibc-i18ndata python ruby python3 python3-pip cf-cli
 
 RUN zypper ar --priority 100 https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo && \
-zypper --gpg-auto-import-keys -n in -y --from=devel_languages_go go1.13
+  zypper --gpg-auto-import-keys -n in --no-recommends -y --from=devel_languages_go go1.13
 
 RUN zypper ar --priority 100 https://download.opensuse.org/repositories/Cloud:Tools/openSUSE_Tumbleweed/Cloud:Tools.repo && \
-zypper --gpg-auto-import-keys -n in --no-recommends -y kubernetes-client
+  zypper --gpg-auto-import-keys -n in --no-recommends -y kubernetes-client
 
 # k8s backends dependencies:
-RUN zypper in -y terraform aws-cli aws-iam-authenticator
+RUN zypper in --no-recommends -y terraform aws-cli aws-iam-authenticator
 
 RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz && \
   tar -xvf google-cloud-sdk.tar.gz && \
@@ -28,6 +28,8 @@ RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/r
 
 RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
 RUN mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
+
+RUN zypper clean --all
 
 ADD . /catapult
 WORKDIR /catapult

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,19 @@ zypper --gpg-auto-import-keys -n in -y --from=devel_languages_go go1.13
 RUN zypper ar --priority 100 https://download.opensuse.org/repositories/Cloud:Tools/openSUSE_Tumbleweed/Cloud:Tools.repo && \
 zypper --gpg-auto-import-keys -n in --no-recommends -y kubernetes-client
 
-RUN zypper in -y python-xml
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-RUN unzip awscli-bundle.zip
-RUN ./awscli-bundle/install
-RUN rm -rf awscli-bundle*
-RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
-RUN chmod +x aws-iam-authenticator && mv aws-iam-authenticator bin/
+# k8s backends dependencies:
+RUN zypper in -y terraform aws-cli aws-iam-authenticator
+
+RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz && \
+  tar -xvf google-cloud-sdk.tar.gz && \
+  rm google-cloud-sdk.tar.gz && \
+  pushd google-cloud-sdk || exit && \
+  bash ./install.sh -q && \
+  popd || exit && \
+  echo "source /google-cloud-sdk/path.bash.inc" >> ~/.bashrc
+
+RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
+RUN mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
 
 ADD . /catapult
 WORKDIR /catapult

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM opensuse/tumbleweed:latest
-RUN zypper ref && zypper in -y git zip wget docker ruby gzip make jq curl which unzip direnv
+# Catapult dependencies:
+RUN zypper ref && zypper in -y git zip wget docker ruby gzip make jq python-yq curl which unzip bazel1.2 direnv
 RUN echo 'eval $(direnv hook bash)' >> ~/.bashrc
+
+RUN wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_linux" -O yaml-patch
+RUN mv yaml-patch /usr/local/bin && chmod +x /usr/local/bin/yaml-patch
+
 # Extras, mostly for the terminal image (that could be split in another image)
-RUN zypper in -y vim zsh tmux glibc-locale glibc-i18ndata python ruby python3 python3-pip
+RUN zypper in -y vim zsh tmux glibc-locale glibc-i18ndata python ruby python3 python3-pip cf-cli
 
+RUN zypper ar --priority 100 https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo && \
+zypper --gpg-auto-import-keys -n in -y --from=devel_languages_go go1.13
 
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo
-RUN zypper --gpg-auto-import-keys -n in --from=devel_languages_go go1.13
-
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin/kubectl
-
-RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
-RUN mv cf /usr/local/bin && chmod +x /usr/local/bin/cf
+RUN zypper ar --priority 100 https://download.opensuse.org/repositories/Cloud:Tools/openSUSE_Tumbleweed/Cloud:Tools.repo && \
+zypper --gpg-auto-import-keys -n in --no-recommends -y kubernetes-client
 
 RUN zypper in -y python-xml
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"

--- a/backend/aks/Makefile
+++ b/backend/aks/Makefile
@@ -6,12 +6,12 @@ kubeconfig:
 
 .PHONY: clean
 clean:
-	echo "not implemented yet" && exit 1
+	./clean.sh
 
 .PHONY: deps
 deps:
-	echo "not implemented yet" && exit 1
+	./deps.sh
 
 .PHONY: all
-all:
-	echo "not implemented yet" && exit 1
+all: deps
+	echo "not implemented yet" && exit 0

--- a/backend/aks/clean.sh
+++ b/backend/aks/clean.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+. ../../include/common.sh
+
+if [ -d "$BUILD_DIR" ]; then
+    # TODO call terraform destroy when needed
+    rm -rf "$BUILD_DIR"
+fi

--- a/backend/aks/deps.sh
+++ b/backend/aks/deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+. ../../include/common.sh
+. .envrc
+
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading AKS deps, using host binaries"
+    exit 0
+fi
+
+azclipath=bin/az
+if [ ! -e "$azclipath" ]; then
+    # needs gcc libffi-devel python3-devel libopenssl-devel
+    curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
+        printf "$(pwd)/.lib/azure-cli\n$(pwd)/bin\ny\n$(pwd)/.envrc\n" | python3 ./install.py && \
+        rm ./install.py
+fi

--- a/backend/eks/deps.sh
+++ b/backend/eks/deps.sh
@@ -24,7 +24,10 @@ if [ ! -e "$awspath" ]; then
     unzip awscli-bundle.zip
     ./awscli-bundle/install --install-dir="$(pwd)"/.local/ --bin-location="$(pwd)"/bin/aws
     rm -rf awscli-bundle*
+fi
 
+awsiampath=bin/aws-iam-authenticator
+if [ ! -e "$awsiampath" ]; then
     curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
     chmod +x aws-iam-authenticator && mv aws-iam-authenticator bin/
 fi

--- a/backend/eks/deps.sh
+++ b/backend/eks/deps.sh
@@ -9,11 +9,16 @@ if [[ "$DOWNLOAD_BINS" == "false" ]]; then
 fi
 
 
-# pin the kubectl to eks default version. Hardcoded as the URL has a changing date stamp
-curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
-chmod +x kubectl && mv kubectl bin/
 
-if ! which aws ; then
+awskubectlpath=bin/kubectl
+if [ ! -e "$awskubectlpath" ]; then
+    # pin the kubectl to eks default version. Hardcoded as the URL has a changing date stamp
+    curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
+    chmod +x kubectl && mv kubectl bin/
+fi
+
+awspath=bin/aws
+if [ ! -e "$awspath" ]; then
     mkdir -p .local
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
     unzip awscli-bundle.zip
@@ -24,8 +29,10 @@ if ! which aws ; then
     chmod +x aws-iam-authenticator && mv aws-iam-authenticator bin/
 fi
 
-curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
-# curl -o terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-unzip terraform.zip
-chmod +x terraform && mv terraform bin/
-rm -rf terraform.zip
+terraformpath=bin/terraform
+if [ ! -e "$terraformpath" ]; then
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+    # curl -o terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
+    unzip terraform.zip && rm -rf terraform.zip
+    chmod +x terraform && mv terraform bin/
+fi

--- a/backend/eks/deps.sh
+++ b/backend/eks/deps.sh
@@ -3,8 +3,8 @@
 . ../../include/common.sh
 . .envrc
 
-if [[ "$DOWNLOAD_BINS" == "false" ]]; then
-    ok "Skipping downloading deps, using host binaries"
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading EKS deps, using host binaries"
     exit 0
 fi
 

--- a/backend/gke/deps.sh
+++ b/backend/gke/deps.sh
@@ -8,15 +8,20 @@ if [[ "$DOWNLOAD_BINS" == "false" ]]; then
     exit 0
 fi
 
-curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz
-tar -xvf google-cloud-sdk.tar.gz
-rm google-cloud-sdk.tar.gz
-pushd google-cloud-sdk || exit
-bash ./install.sh -q
-popd || exit
-echo "source $(pwd)/google-cloud-sdk/path.bash.inc" >> .envrc
+gcloudpath=bin/gcloud
+if [ ! -e "$gcloudpath" ]; then
+    curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz
+    tar -xvf google-cloud-sdk.tar.gz
+    rm google-cloud-sdk.tar.gz
+    pushd google-cloud-sdk || exit
+    bash ./install.sh -q
+    popd || exit
+    echo "source $(pwd)/google-cloud-sdk/path.bash.inc" >> .envrc
+fi
 
-curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
-unzip terraform.zip
-chmod +x terraform && mv terraform bin/
-rm -rf terraform.zip
+terraformpath=bin/terraform
+if [ ! -e "$terraformpath" ]; then
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+    unzip terraform.zip && rm -rf terraform.zip
+    chmod +x terraform && mv terraform bin/
+fi

--- a/backend/gke/deps.sh
+++ b/backend/gke/deps.sh
@@ -3,8 +3,8 @@
 . ../../include/common.sh
 . .envrc
 
-if [[ "$DOWNLOAD_BINS" == "false" ]]; then
-    ok "Skipping downloading deps, using host binaries"
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading GKE deps, using host binaries"
     exit 0
 fi
 

--- a/backend/kind/deps.sh
+++ b/backend/kind/deps.sh
@@ -4,8 +4,8 @@
 . ../../include/common.sh
 . .envrc
 
-if [[ "$DOWNLOAD_BINS" == "false" ]]; then
-    ok "Skipping downloading deps, using host binaries"
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading kind deps, using host binaries"
     exit 0
 fi
 

--- a/backend/kind/deps.sh
+++ b/backend/kind/deps.sh
@@ -2,6 +2,7 @@
 
 . ./defaults.sh
 . ../../include/common.sh
+. .envrc
 
 if [[ "$DOWNLOAD_BINS" == "false" ]]; then
     ok "Skipping downloading deps, using host binaries"
@@ -14,13 +15,16 @@ else
   export KIND_OS_TYPE="${KIND_OS_TYPE:-kind-linux-amd64}"
 fi
 
-if [[ $KIND_VERSION =~ ^0\.2\.[0-9]$ ]]; then
-  curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/${KIND_OS_TYPE}
-else
-  curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/${KIND_OS_TYPE}
+
+kindpath=bin/kind
+if [ ! -e "$kindpath" ]; then
+    if [[ $KIND_VERSION =~ ^0\.2\.[0-9]$ ]]; then
+        curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/${KIND_OS_TYPE}
+    else
+        curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/${KIND_OS_TYPE}
+    fi
+    chmod +x kind && mv kind $kindpath
 fi
-chmod +x kind
-mv kind bin/kind
 
 popd || exit
 

--- a/backend/minikube/deps.sh
+++ b/backend/minikube/deps.sh
@@ -3,6 +3,10 @@
 . ../../include/common.sh
 . .envrc
 
+if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
+    ok "Skipping downloading kind deps, using host binaries"
+    exit 0
+fi
 
 MINIKUBE_VERSION=latest
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/backend/minikube/deps.sh
+++ b/backend/minikube/deps.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 
-# duplicated in s/include/common.sh, needed for bootstrapping:
-export CLUSTER_NAME=${CLUSTER_NAME:-minikube}
-
 . ../../include/common.sh
+. .envrc
 
 
 MINIKUBE_VERSION=latest
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
     MINIKUBE_BIN=minikube-darwin-amd64
 else
     MINIKUBE_BIN=minikube-linux-amd64
 fi
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/"$MINIKUBE_VERSION"/"$MINIKUBE_BIN"
-chmod +x minikube && mv minikube bin/
-curl -Lo docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
-chmod +x docker-machine-driver-kvm2 && mv docker-machine-driver-kvm2 bin/
+minikubepath=bin/minikube
+if [ ! -e "$minikubepath" ]; then
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"$MINIKUBE_VERSION"/"$MINIKUBE_BIN"
+    chmod +x minikube && mv minikube bin/
+fi
+
+dockermachinedriverkvm2path=bin/docker-machine-driver-kvm2
+if [ ! -e "$dockermachinedriverkvm2path" ]; then
+    curl -Lo docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2
+    chmod +x docker-machine-driver-kvm2 && mv docker-machine-driver-kvm2 bin/
+fi
 
 popd || exit

--- a/include/func.sh
+++ b/include/func.sh
@@ -220,7 +220,7 @@ function wait_ns {
 
 function helm_info {
     if [[ "$HELM_VERSION" == v3* ]]; then
-        helm version
+        helm version --kubeconfig /dev/null
     else
         helm version --client
     fi

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -23,28 +23,32 @@ fi
 if [[ "$DOWNLOAD_BINS" == "false" ]]; then
     ok "Skipping downloading bins, using host binaries"
 else
+    info "Downloading specific helm, kubectl, cf versions…"
     if [ ! -e "bin/helm" ]; then
-        curl -L https://get.helm.sh/helm-${HELM_VERSION}-${HELM_OS_TYPE}.tar.gz | tar zxf -
+        curl -sL https://get.helm.sh/helm-${HELM_VERSION}-${HELM_OS_TYPE}.tar.gz | tar zxf -
         mv $HELM_OS_TYPE/helm bin/
         if [ -e "$HELM_OS_TYPE/tiller" ]; then
             mv $HELM_OS_TYPE/tiller bin/
         fi
         rm -rf "$HELM_OS_TYPE"
+        info "Helm version:"
         helm_info
     fi
 
     if [ ! -e "bin/kubectl" ]; then
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${KUBECTL_OS_TYPE}/amd64/kubectl
+        curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${KUBECTL_OS_TYPE}/amd64/kubectl
         mv kubectl bin/
         chmod +x bin/kubectl
+        info "Kubectl version:"
         kubectl version 2>&1 | grep Client || true
     fi
 
     if [ ! -e "bin/cf" ]; then
-        curl -L "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&source=github" | tar -zx
+        curl -sL "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&source=github" | tar -zx
         mv cf bin/
         rm -rf "$CFCLI_OS_TYPE" LICENSE NOTICE
         chmod +x bin/cf
+        info "CF cli version:"
         cf version
     fi
 fi

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -44,7 +44,9 @@ tearDown() {
 
 testKind() {
     rm -rf buildtest
-    BACKEND=kind make k8s
+    BACKEND=kind DOWNLOAD_CATAPULT_DEPS=true make k8s
+    # with DOWNLOAD_CATAPULT_DEPS=true the following needs to happen:
+    assertTrue 'kind binary is present' "[ -f 'buildtest/bin/kind' ]"
     deployst=$?
     echo "DEPLOYS: $deployst"
     assertTrue 'create buildir' "[ -d 'buildtest' ]"

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -187,6 +187,44 @@ testCommonDeps() {
   assertTrue 'bazel downloaded' "[ -e 'buildtest/bin/bazel' ]"
   assertTrue 'yaml-patch downloaded' "[ -e 'buildtest/bin/yaml-patch' ]"
   assertTrue 'yq downloaded' "[ -e 'buildtest/bin/yq' ]"
+
+  # test DOWNLOAD_CATAPULT_DEPS=false on all backends
+  for b in kind caasp4os eks gke imported minikube aks; do
+      if [ -d "$ROOT_DIR/backend/$b" ]; then
+          rm -rf buildtest
+          BACKEND="$b" DOWNLOAD_CATAPULT_DEPS=false make buildir
+          BACKEND="$b" DOWNLOAD_BINS=false DOWNLOAD_CATAPULT_DEPS=false make private backend/$b deps
+          assertTrue 'create buildir' "[ -d 'buildtest' ]"
+          ENVRC="$(cat "$PWD"/buildtest/.envrc)"
+          case $b in
+              caasp4os)
+                  assertFalse 'terraform not downloaded' "[ -e 'buildtest/bin/terraform' ]"
+                  ;;
+              kind)
+                  assertFalse 'kind not downloaded' "[ -e 'buildtest/bin/kind' ]"
+                  ;;
+              aws)
+                  assertFalse 'aws not downloaded' "[ -e 'buildtest/bin/aws' ]"
+                  assertFalse 'aws-iam-authenticator not downloaded' "[ -e 'buildtest/bin/aws-iam-authenticator' ]"
+                  assertFalse 'terraform not downloaded' "[ -e 'buildtest/bin/terraform' ]"
+                  ;;
+              gke)
+                  assertFalse 'gcloud not downloaded' "[ -e 'buildtest/bin/gcloud' ]"
+                  assertFalse 'terraform not downloaded' "[ -e 'buildtest/bin/terraform' ]"
+                  ;;
+              minikube)
+                  assertFalse 'minikube not downloaded' "[ -e 'buildtest/bin/minikube' ]"
+                  assertFalse 'docker-machine-driver-kvm2 not downloaded' "[ -e 'buildtest/bin/docker-machine-driver-kvm2' ]"
+                  ;;
+              aks)
+                  assertFalse 'az not downloaded' "[ -e 'buildtest/bin/az' ]"
+                  assertFalse 'terraform not downloaded' "[ -e 'buildtest/bin/terraform' ]"
+                  ;;
+          esac
+          BACKEND="$b" make clean
+          assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
+      fi
+  done
 }
 
 # Load shUnit2.


### PR DESCRIPTION
Add to Dockerfile:
  - catapult deps: `yq`, `bazel`, `yaml-patch`. Add one version of `kubectl, cf-cli` each, for convenience
  - k8s provider deps: `aws-cli`, `aws iam`, `gcloud`, `az`, `terraform`

Clean and reduce catapult image

Don't dowload deps if they are already in `buildfolder/bin/*`

Use `DOWNLOAD_CATAPULT_DEPS` everywhere, which allows pipelines to skip downloads. Default to true so normal users will download deps.

