### PR TITLE
Enable HA correctly for kubecf

### DIFF
--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -89,6 +89,7 @@ services:
       start: 20000
       end: 20008
 
+high_availability: ${HA}
 
 EOF
 


### PR DESCRIPTION
Consume `high_availability` option correctly.

See:
https://github.com/cloudfoundry-incubator/kubecf/blob/d7bc0ef05b947d74f0769fa00365fc5c848e0ad3/deploy/helm/kubecf/values.yaml#L146

