### PR TITLE
Make sure br_netfilter is loaded so that kind works

### DIFF
--- a/backend/kind/deps.sh
+++ b/backend/kind/deps.sh
@@ -15,6 +15,8 @@ else
   export KIND_OS_TYPE="${KIND_OS_TYPE:-kind-linux-amd64}"
 fi
 
+# needed by kind
+sudo -n /sbin/modprobe br_netfilter  || :
 
 kindpath=bin/kind
 if [ ! -e "$kindpath" ]; then


### PR DESCRIPTION
Without that, there is this error:
  cat: can't open '/proc/sys/net/bridge/bridge-nf-call-iptables': No such file or directory