### PR TITLE
Use lb service type for stratos

### DIFF
--- a/modules/stratos/gen-config.sh
+++ b/modules/stratos/gen-config.sh
@@ -34,6 +34,10 @@ cat <<EOF > op.yml
   path: /kube/organization
   value:
     "${DOCKER_ORG}"
+- op: add
+  path: /services
+  value:
+    loadbalanced: true
 EOF
 
 yamlpatch op.yml scf-config-values-for-stratos.yaml


### PR DESCRIPTION
Currently inaccessible on CaaSP deployments with ClusterIP svc type