### PR TITLE
enable gke cluster name, update to catapult docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,10 @@ RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.
 RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
   chmod +x aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
 
-RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-264.0.0-linux-x86_64.tar.gz && \
-  tar -xvf google-cloud-sdk.tar.gz && \
-  rm google-cloud-sdk.tar.gz && \
-  pushd google-cloud-sdk || exit && \
-  bash ./install.sh -q && \
-  popd || exit && \
-  echo "source /google-cloud-sdk/path.bash.inc" >> ~/.bashrc
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz \
+&& mkdir -p /usr/local/gcloud \
+&& tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+&& /usr/local/gcloud/google-cloud-sdk/install.sh --quiet
 
 RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl && \
   mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
@@ -45,6 +42,11 @@ RUN zypper in --no-recommends -y gcc libffi-devel python3-devel libopenssl-devel
 RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
   printf "\n\n\n\n" | python3 ./install.py && \
   rm ./install.py
+
+RUN helm_version=v3.1.1 \
+&& wget https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz -O - | tar xz -C /usr/bin --strip-components=1 linux-amd64/helm
+
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 RUN zypper clean --all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN zypper ar --priority 100 https://download.opensuse.org/repositories/devel:/l
 RUN zypper ar --priority 100 https://download.opensuse.org/repositories/Cloud:Tools/openSUSE_Tumbleweed/Cloud:Tools.repo && \
   zypper --gpg-auto-import-keys -n in --no-recommends -y Cloud_Tools:kubernetes-client
 
+RUN helm_version=v3.1.1 \
+&& wget https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz -O - | tar xz -C /usr/bin --strip-components=1 linux-amd64/helm
+
 # k8s backends dependencies:
 RUN zypper in --no-recommends -y terraform
 
@@ -42,9 +45,6 @@ RUN zypper in --no-recommends -y gcc libffi-devel python3-devel libopenssl-devel
 RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
   printf "\n\n\n\n" | python3 ./install.py && \
   rm ./install.py
-
-RUN helm_version=v3.1.1 \
-&& wget https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz -O - | tar xz -C /usr/bin --strip-components=1 linux-amd64/helm
 
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -24,16 +24,16 @@ git clone https://github.com/SUSE/cap-terraform.git
 pushd cap-terraform/gke || exit
 
 cat <<HEREDOC > terraform.tfvars
-project = "$GKE_PROJECT"
-location = "$GKE_LOCATION"
+project        = "$GKE_PROJECT"
+location       = "$GKE_LOCATION"
 node_pool_name = "$GKE_CLUSTER_NAME"
-node_count = "$GKE_NODE_COUNT"
-vm_type = "UBUNTU"
-gke_sa_key = "$GKE_CRED_JSON"
+node_count     = "$GKE_NODE_COUNT"
+vm_type        = "UBUNTU"
+gke_sa_key     = "$GKE_CRED_JSON"
 gcp_dns_sa_key = "$GKE_CRED_JSON"
 cluster_labels = {key = "$GKE_CLUSTER_NAME"}
-cluster_name= "$GKE_CLUSTER_NAME"
-k8s_version = "latest"
+cluster_name   = "$GKE_CLUSTER_NAME"
+k8s_version    = "latest"
 HEREDOC
 
 # terraform needs helm client installed and configured:

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -22,7 +22,6 @@ fi
 
 git clone https://github.com/SUSE/cap-terraform.git
 pushd cap-terraform/gke || exit
-git checkout -t origin/prabal-gke-clustername-tfvar
 
 cat <<HEREDOC > terraform.tfvars
 project = "$GKE_PROJECT"

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -22,6 +22,7 @@ fi
 
 git clone https://github.com/SUSE/cap-terraform.git
 pushd cap-terraform/gke || exit
+git checkout -t origin/prabal-gke-clustername-tfvar
 
 cat <<HEREDOC > terraform.tfvars
 project = "$GKE_PROJECT"
@@ -32,6 +33,7 @@ vm_type = "UBUNTU"
 gke_sa_key = "$GKE_CRED_JSON"
 gcp_dns_sa_key = "$GKE_CRED_JSON"
 cluster_labels = {key = "$GKE_CLUSTER_NAME"}
+cluster_name= "$GKE_CLUSTER_NAME"
 k8s_version = "latest"
 HEREDOC
 


### PR DESCRIPTION
catapult was only setting label for gke cluster. With this PR, catapult will set cluster name along with label for gke cluster. This is required for CAP CI work, where we want to control cluster name and label.

This PR also fixes path for gcloud cli and adds helm to catapult docker image.