### PR TITLE
Use compute-optimized flavour instead of memory one for CaaSP

### DIFF
--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -41,12 +41,12 @@ workers = 3
 # Size of the master nodes
 # EXAMPLE:
 # master_size = "m1.medium"
-master_size = "m1.xlarge"
+master_size = "c8.large"
 
 # Size of the worker nodes
 # EXAMPLE:
 # worker_size = "m1.medium"
-worker_size = "m1.xxlarge"
+worker_size = "c8.large"
 
 # Attach persistent volumes to workers
 workers_vol_enabled = 0


### PR DESCRIPTION
Use:
  c8.large: 	8 vcpus, 	8 GB ram,  160 GB disk
instead of:
  m1.xlarge: 	4 vcpus,	16 GB ram, 160 GB disk
  m1.xxlarge: 4 vcpus,	20 GB ram,	80 GB disk