### PR TITLE
Cleanup EKS cluster via eksctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tm
 RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl && \
   mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
 
+RUN curl --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" | tar xz -C /usr/local/bin && \
+  chmod +x /usr/local/bin/eksctl
+
 RUN zypper in --no-recommends -y gcc libffi-devel python3-devel libopenssl-devel
 RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
   printf "\n\n\n\n" | python3 ./install.py && \

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -8,13 +8,31 @@
 if [ -d "$BUILD_DIR" ]; then
     . .envrc
 
+    # TODO: Get this as terraform output
+    # Currently assumes an exact structure of the kubeconfig
+    eks_cluster_name="$(cat kubeconfig \
+                    | yq '.users[0].user.exec.args[2]' \
+                    2>/dev/null|head -n1)"
 
-    if [ -d "cap-terraform/eks" ]; then
-        pushd cap-terraform/eks || exit
-        terraform destroy -auto-approve
-        popd || exit
-        rm -rf cap-terraform
-    fi
+    # See above, having it as proper terraform output is better.
+    # if [ -d "cap-terraform/eks" ]; then
+    #     eks_cluster_name="$(cd cap-terraform/eks ; terraform output cluster_name)"
+    # fi
+
+    eksctl delete cluster --name "${eks_cluster_name}"
+
+    # Activate if eksctl is good
+    # if [ -d "cap-terraform/eks" ]; then
+    #     rm -rf cap-terraform
+    # fi
+
+    # Old code disabled
+    # if [ -d "cap-terraform/eks" ]; then
+    #     pushd cap-terraform/eks || exit
+    #     terraform destroy -auto-approve
+    #     popd || exit
+    #     rm -rf cap-terraform
+    # fi
 
     popd || exit
     rm -rf "$BUILD_DIR"

--- a/backend/eks/clean.sh
+++ b/backend/eks/clean.sh
@@ -10,9 +10,7 @@ if [ -d "$BUILD_DIR" ]; then
 
     # TODO: Get this as terraform output
     # Currently assumes an exact structure of the kubeconfig
-    eks_cluster_name="$(cat kubeconfig \
-                    | yq '.users[0].user.exec.args[2]' \
-                    2>/dev/null|head -n1)"
+    eks_cluster_name="$(cat kubeconfig | yq r - 'users[0].user.exec.args[2]')"
 
     # See above, having it as proper terraform output is better.
     # if [ -d "cap-terraform/eks" ]; then

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -23,7 +23,7 @@ fi
 if [[ "$DOWNLOAD_BINS" == "false" ]]; then
     ok "Skipping downloading bins, using host binaries"
 else
-    info "Downloading specific helm, kubectl, cf versions…"
+    info "Downloading specific helm, kubectl, cf, eksctl versions…"
     if [ ! -e "bin/helm" ]; then
         curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-${HELM_OS_TYPE}.tar.gz | tar zxf -
         mv $HELM_OS_TYPE/helm bin/
@@ -62,7 +62,6 @@ else
         eksctl version
     fi
 fi
-
 
 if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
     ok "Skipping downloading catapult dependencies, using host binaries"

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -51,6 +51,16 @@ else
         info "CF cli version:"
         cf version
     fi
+
+    if [ ! -e "bin/eksctl" ]; then
+	curl --silent --location \
+	     "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+	    | tar xz
+        mv eksctl bin/
+        chmod +x bin/eksctl
+        info "eksctl version:"
+        eksctl version
+    fi
 fi
 
 


### PR DESCRIPTION
References
- https://jira.suse.com/browse/CAP-1395
- https://github.com/SUSE/catapult/issues/177

Modifications
- Added `eksctl` to the set of installed dependencies/tools.
- Changed eks `clean.sh` to drop use of `terraform destroy` and use `eksctl delete cluster` instead.
  Cluster name is extracted from the `kubeconfig` file generated by terraform during setup.
  Brittle, relies on exact kubeconfig structure.
  Needs a `cap-terraform` PR adding this information as proper tf output.

:warning: :construction: To be tested :construction: :warning: 

