### PR TITLE
gke ClusterReference file, fix terraform for darwin

### DIFF
--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -48,8 +48,8 @@ terraform plan -out="$(pwd)"/my-plan
 terraform apply -auto-approve
 popd || exit
 
-# Create ClusterReference file for kubeconfig generation
-cat << EOF > ClusterReference.yaml
+# Create kubeclusterreference file for kubeconfig generation
+cat << EOF > kubeclusterreference
 ---
 kind: ClusterReference
 platform: gke

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -48,6 +48,16 @@ terraform plan -out="$(pwd)"/my-plan
 terraform apply -auto-approve
 popd || exit
 
+# Create ClusterReference file for kubeconfig generation
+cat << EOF > ClusterReference.yaml
+---
+kind: ClusterReference
+platform: gke
+cluster-name: ${GKE_CLUSTER_NAME}
+cluster-zone: ${GKE_LOCATION}
+project: ${GKE_PROJECT}
+EOF
+
 # wait for cluster ready:
 wait_ns kube-system
 

--- a/backend/gke/deps.sh
+++ b/backend/gke/deps.sh
@@ -21,7 +21,11 @@ fi
 
 terraformpath=bin/terraform
 if [ ! -e "$terraformpath" ]; then
-    curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_darwin_amd64.zip
+    else
+        curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+    fi
     unzip terraform.zip && rm -rf terraform.zip
     chmod +x terraform && mv terraform bin/
 fi

--- a/backend/gke/kubeconfig.sh
+++ b/backend/gke/kubeconfig.sh
@@ -1,25 +1,24 @@
 #!/usr/bin/env bash
 
 # KUBECFG can be a kubeconfig file or a cluster reference file for local deployments
-# KUBECFG has to be a ClusterReference.yaml for CI usage, check gke/deploy.sh for format
+# KUBECFG has to be a kubeclusterreference for CI usage, check gke/deploy.sh for format
 if [ ! -f "$KUBECFG" ]; then
     err "No KUBECFG given - you need to pass one!"
     exit 1
 fi
 
-if grep -Fxq "kind: ClusterReference" ${KUBECFG}; then
-    # Process ClusterReference file
-    echo "Processing ClusterReference.yaml ..."
-    ClusterReference_file=$KUBECFG
-    GKE_CLUSTER_NAME="$(yq r ${ClusterReference_file} cluster-name)"
-    export GKE_CLUSTER_NAME
-    GKE_CLUSTER_ZONE="$(yq r ${ClusterReference_file} cluster-zone)"
-    export GKE_CLUSTER_ZONE
-    GKE_PROJECT="$(yq r ${ClusterReference_file} project)"
-    export GKE_PROJECT
+if [[ $(yq r ${KUBECFG} kind) == "ClusterReference" ]]; then
+    # Process kubeclusterreference file
+    echo "Using kubeclusterreference ..."
+    GKE_CLUSTER_NAME="$(yq r ${KUBECFG} cluster-name)"
+    GKE_CLUSTER_ZONE="$(yq r ${KUBECFG} cluster-zone)"
+    GKE_PROJECT="$(yq r ${KUBECFG} project)"
+    export GKE_CLUSTER_NAME GKE_CLUSTER_ZONE GKE_PROJECT
+elif [[ $(yq r ${KUBECFG} kind) == "Config" ]]; then
+    echo "Using kubeconfig ..."
 else
-    echo "ClusterReference.yaml is not of correct format or has not been provided"
-    echo "Processing $KUBECFG as a kubeconfig.yaml ..."
+    echo "Please check your KUBECFG"
+    exit 1
 fi
 
 . ./defaults.sh

--- a/backend/gke/kubeconfig.sh
+++ b/backend/gke/kubeconfig.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 
-. ./defaults.sh
-. ../../include/common.sh
-. .envrc
-
 if [ ! -f "$KUBECFG" ]; then
     err "No KUBECFG given - you need to pass one!"
     exit 1
 fi
+# usage: read_yaml_key test.yaml key-name
+read_yaml_key() {
+    ruby -r yaml -e "puts YAML.load_file('$1')[\"$2\"]"
+}
+
+# Process ClusterReference file
+ClusterReference_file=$KUBECFG
+GKE_CLUSTER_NAME="$(read_yaml_key ${ClusterReference_file} cluster-name)"
+export GKE_CLUSTER_NAME
+GKE_CLUSTER_ZONE="$(read_yaml_key ${ClusterReference_file} cluster-zone)"
+export GKE_CLUSTER_ZONE
+GKE_PROJECT_ID="$(read_yaml_key ${ClusterReference_file} project)"
+export GKE_PROJECT_ID
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
 
 # check gcloud credentials:
 info "Using creds from GKE_CRED_JSON…"
@@ -16,8 +29,7 @@ gcloud auth activate-service-account --project "$GKE_PROJECT" --key-file "$GKE_C
 if [[ $(gcloud auth list  --format="value(account)" | wc -l ) -le 0 ]]; then
     err "GKE_CRED_JSON creds don't authenticate, aborting" && exit 1
 fi
-
-cp "$KUBECFG" kubeconfig
+gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE}
 
 # kubeconfig gets hardcoded paths for gcloud bin, reevaluate them:
 gcloud_path="$(which gcloud)"


### PR DESCRIPTION
- create additional Cluster reference file to create kubeconfigs using gcloud. We cannot use kubeconfigs directly for CI as gcloud creates kubeconfigs with expiry.
- install tf for darwin in gke backend