### PR TITLE
Save EKS cluster name to dedicated file

### DIFF
--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -7,6 +7,8 @@
 . ../../include/common.sh
 . .envrc
 
+set -x
+
 if ! aws sts get-caller-identity ; then
     info "Missing aws credentials, running aws configure…"
     # Use predefined aws env vars
@@ -15,6 +17,9 @@ if ! aws sts get-caller-identity ; then
 fi
 
 git clone https://github.com/SUSE/cap-terraform.git
+
+( cd cap-terraform ; git checkout ak-cap-1395-kubecf-177-output-cluster-name )
+
 pushd cap-terraform/eks || exit
 
 # terraform needs helm client installed and configured:

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -39,6 +39,9 @@ terraform apply -auto-approve
 # or:
 terraform output kubeconfig > "$KUBECONFIG"
 
+# get cluster name for eks
+terraform output cluster-name > "$(dirname "$KUBECONFIG")/cap-cluster-name"
+
 # test deployment:
 kubectl get svc
 


### PR DESCRIPTION
Ref: https://jira.suse.com/browse/CAP-1395
Requires https://github.com/SUSE/cap-terraform/pull/58

The retrieved name is saved into a file, for pickup by catapult's user, like a CI pipeline.
