### PR TITLE
Implement state save/restore to s3 for terraform

### DIFF
--- a/backend/eks/defaults.sh
+++ b/backend/eks/defaults.sh
@@ -16,11 +16,11 @@ HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 TF_KEY="${TF_KEY:-}"
 #
 # s3 bucket and bucket region to save state to. Ignored when
-# EKS_TF_KEY is empty (default, see above).
+# TF_KEY is empty (default, see above).
 TF_BUCKET="${TF_BUCKET:-cap-ci-tf}"
 TF_REGION="${TF_REGION:-${EKS_LOCATION}}"
 
 # DNS information (Route53). No defaults. Required.
-#R53_ZONE_ID
-#R53_ZONE_NAME
-#R53_ZONE_POLICY
+#EKS_ZONE_ID
+#EKS_ZONE_NAME
+#EKS_ZONE_POLICY

--- a/backend/eks/defaults.sh
+++ b/backend/eks/defaults.sh
@@ -9,3 +9,18 @@ EKS_VERS="${EKS_VERS:-1.14}"
 EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-\{key = \"$(whoami)-eks-cluster\"\}}
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 # EKS_KUBECTL_VERSION not to be defined as the eks kubectl is hardcoded in deps.sh
+
+# Settings for terraform state save/restore
+#
+# Set to a non-empty key to trigger state save in deploy.sh.
+TF_KEY="${TF_KEY:-}"
+#
+# s3 bucket and bucket region to save state to. Ignored when
+# EKS_TF_KEY is empty (default, see above).
+TF_BUCKET="${TF_BUCKET:-cap-ci-tf}"
+TF_REGION="${TF_REGION:-${EKS_LOCATION}}"
+
+# DNS information (Route53). No defaults. Required.
+#R53_ZONE_ID
+#R53_ZONE_NAME
+#R53_ZONE_POLICY

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -14,8 +14,6 @@ if ! aws sts get-caller-identity ; then
     aws configure
 fi
 
-MAIN="${PWD}"
-
 git clone https://github.com/SUSE/cap-terraform.git
 pushd cap-terraform/eks || exit
 
@@ -28,9 +26,9 @@ workstation_cidr_block = "0.0.0.0/0"
 keypair_name = "$EKS_KEYPAIR"
 eks_version = "$EKS_VERS"
 cluster_labels = $EKS_CLUSTER_LABEL
-hosted_zone_id = "${R53_ZONE_ID}"
-hosted_zone_name = "${R53_ZONE_NAME}"
-hosted_zone_policy_arn = "${R53_ZONE_POLICY}"
+hosted_zone_id = "${EKS_ZONE_ID}"
+hosted_zone_name = "${EKS_ZONE_NAME}"
+hosted_zone_policy_arn = "${EKS_ZONE_POLICY}"
 instance_type = "t2.large"
 HEREDOC
 
@@ -50,7 +48,7 @@ terraform init
 terraform plan -out=my-plan
 
 if [ -n "${TF_KEY}" ] ; then
-    zip -r9  "${MAIN}/tf-setup.zip" .
+    zip -r9  "${BUILD_DIR}/tf-setup.zip" .
 fi
 
 terraform apply -auto-approve my-plan

--- a/backend/eks/kubeconfig.sh
+++ b/backend/eks/kubeconfig.sh
@@ -18,9 +18,9 @@ mtype=$(file --mime-type "$KUBECFG" |awk '{ print $2}')
 # Note: Current working directory is the active buildXXX environment, as needed.
 
 if [[ $mtype == "application/zip" ]] ; then
-    echo "Using Terraform state ..."
+    info "Using Terraform state ..."
 
-    ( cd cap-terraform/eks
+    ( cd cap-terraform/eks || exit
       # ATTENTION: The next command overwrites existing files without
       # prompting.
       unzip -o "$KUBECFG"
@@ -29,17 +29,16 @@ if [[ $mtype == "application/zip" ]] ; then
       terraform apply -auto-approve
     )
     # And reconstruct the kubeconfig from it.
-    ( cd cap-terraform/eks
+    ( cd cap-terraform/eks || exit
       terraform output kubeconfig
     ) > kubeconfig
 
 elif [[ $mtype == "text/plain" ]] ; then
-    echo "Using kubeconfig ..."
+    info "Using kubeconfig ..."
 
     cp "$KUBECFG" kubeconfig
 else
-    echo "Please check your KUBECFG"
-    exit 1
+    err "Please check your KUBECFG"
 fi
 
 if ! aws sts get-caller-identity ; then


### PR DESCRIPTION
Ref https://jira.suse.com/browse/CAP-1395

Trigger config variable: `TF_KEY`. Non-empty triggers state save, and is file name in S3.
Other config variables: `TF_BUCKET`, `TF_REGION`. These have suitable defaults.

Some config variables for DNS to satisfy current cap-tf master.
These very likely will be superseded by work currently done by Satradru.

Configures an s3 backend for tf state.
Captures tf directory (modules, plugins, etc.) in zip file.
This captures the state reference as well.

`kubeconfig` target modified so that it can import such a zip file (unzip, re-apply state, reconstruct kubeconfig from that state).

The general structure is similar to PR #183, with the tf zip file taking the place of the gke cluster reference of 183 as the file which is imported and used to make the required kubeconfig file.