### PR TITLE
Consume cap-ci branch from cap-terraform

### DIFF
--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -14,7 +14,7 @@ if ! aws sts get-caller-identity ; then
     aws configure
 fi
 
-git clone https://github.com/SUSE/cap-terraform.git
+git clone https://github.com/SUSE/cap-terraform.git -b cap-ci
 pushd cap-terraform/eks || exit
 
 # terraform needs helm client installed and configured:

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -20,7 +20,7 @@ fi
 #        --member=user:<user> \
 #        --role=roles/container.admin
 
-git clone https://github.com/SUSE/cap-terraform.git
+git clone https://github.com/SUSE/cap-terraform.git -b cap-ci
 pushd cap-terraform/gke || exit
 
 cat <<HEREDOC > terraform.tfvars


### PR DESCRIPTION
 `cap-ci` branch contains the following fixes:
- `controller.publishService.enabled` on deployment of external-dns for GKE, which fixes creating DNS entries when using ingress
- set a unique `txtOwnerId` in the TXT record for the external-dns chart, which solves DNS entries getting overwritten by different clusters.