### PR TITLE
Introducing retry mechanism in login.sh

### DIFF
--- a/modules/scf/login.sh
+++ b/modules/scf/login.sh
@@ -12,7 +12,16 @@ fi
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 
 mkdir -p "$CF_HOME"
-cf login --skip-ssl-validation -a https://api."$domain" -u admin -p "$CLUSTER_PASSWORD" -o system
+
+# It might take some time for external DNS records to update so make a few attempts to login before bailing out.
+n=0
+until [ $n -ge 20 ]
+do
+   cf login --skip-ssl-validation -a https://api."$domain" -u admin -p "$CLUSTER_PASSWORD" -o system && break
+   n=$[$n+1]
+   sleep 60
+done
+
 cf create-space tmp
 cf target -s tmp
 


### PR DESCRIPTION
This PR addresses an issue with the kubecf deployment script failing on `login.sh` by introducing retry mechanism. The issue happens beacuse external DNS records take some time to update. 