### PR TITLE
Update terraform templates to be compatible with tf 0.12 (Fixes #194)

### DIFF
--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -98,7 +98,7 @@ wait
 # wait
 
 # Create k8s configmap
-PUBLIC_IP="$(skuba_container terraform output ip_workers | cut -d, -f1 | head -n1)"
+PUBLIC_IP="$(skuba_container terraform output -json | jq -r '.ip_workers.value|to_entries|map(.value)|first')"
 ROOTFS=overlay-xfs
 NFS_SERVER_IP="$(skuba_container terraform output ip_storage_int)"
 NFS_PATH="$(skuba_container terraform output storage_share)"

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -7,11 +7,11 @@ SKUBA_CLUSTER_NAME="$CLUSTER_NAME"
 
 _set_env_vars() {
     JSON=$(skuba_container terraform output -json)
-    LB="$(echo "$JSON" | jq -r '.ip_load_balancer.value')"
+    LB="$(echo "$JSON" | jq -r '.ip_load_balancer.value|to_entries|map(.value)|@tsv')"
     export LB
-    MASTERS="$(echo "$JSON" | jq -r '.ip_masters.value|@tsv')"
+    MASTERS="$(echo "$JSON" | jq -r '.ip_masters.value|to_entries|map(.value)|@tsv')"
     export MASTERS
-    WORKERS="$(echo "$JSON" | jq -r '.ip_workers.value|@tsv')"
+    WORKERS="$(echo "$JSON" | jq -r '.ip_workers.value|to_entries|map(.value)|@tsv')"
     export WORKERS
     ALL="$MASTERS $WORKERS"
     export ALL

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -3,7 +3,6 @@
 # Functions to interact with a container that includes the client caasp4
 # binaries and terraform
 
-SKUBA_CLUSTER_NAME="$CLUSTER_NAME"
 
 _set_env_vars() {
     JSON=$(skuba_container terraform output -json)
@@ -47,7 +46,7 @@ skuba_container() {
     # skuba_container <commands to run in a punctured container>
 
     local app_path="$PWD"
-    if [[ "$1" == "$SKUBA_CLUSTER_NAME" ]]; then
+    if [[ "$1" == "$CLUSTER_NAME" ]]; then
         local app_path="$PWD/$1"
         shift
     fi
@@ -162,8 +161,8 @@ skuba_updates() {
 }
 
 _init_control_plane() {
-    if ! [[ -d "$SKUBA_CLUSTER_NAME" ]]; then
-        skuba_container skuba cluster init --control-plane "$LB" "$SKUBA_CLUSTER_NAME"
+    if ! [[ -d "$CLUSTER_NAME" ]]; then
+        skuba_container skuba cluster init --control-plane "$LB" "$CLUSTER_NAME"
     fi
 }
 
@@ -173,12 +172,12 @@ for n in $1; do
     local j
     j="$(printf "%03g" $i)"
     if [[ $i -eq 0 ]]; then
-      skuba_container "$SKUBA_CLUSTER_NAME" skuba node bootstrap --user sles --sudo --target "$n" "master$j" -v "$DEBUG"
+      skuba_container "$CLUSTER_NAME" skuba node bootstrap --user sles --sudo --target "$n" "master$j" -v "$DEBUG"
       wait
     fi
 
     if [[ $i -ne 0 ]]; then
-      skuba_container "$SKUBA_CLUSTER_NAME" skuba node join --role master --user sles --sudo --target  "$n" "master$j" -v "$DEBUG"
+      skuba_container "$CLUSTER_NAME" skuba node join --role master --user sles --sudo --target  "$n" "master$j" -v "$DEBUG"
       wait
     fi
     ((++i))
@@ -190,7 +189,7 @@ _deploy_workers() {
     for n in $1; do
         local j
         j="$(printf "%03g" $i)"
-        (skuba_container "$SKUBA_CLUSTER_NAME" skuba node join --role worker --user sles --sudo --target  "$n" "worker$j" -v "$DEBUG") &
+        (skuba_container "$CLUSTER_NAME" skuba node join --role worker --user sles --sudo --target  "$n" "worker$j" -v "$DEBUG") &
         wait
         ((++i))
     done
@@ -199,12 +198,13 @@ _deploy_workers() {
 skuba_deploy() {
     # Usage: deploy
 
+    set -x
     _set_env_vars
     _init_control_plane
     pushd "$(pwd)"/ || exit
     _deploy_masters "$MASTERS"
     _deploy_workers "$WORKERS"
-    KUBECONFIG="" skuba_container $SKUBA_CLUSTER_NAME skuba cluster status
+    KUBECONFIG="" skuba_container $CLUSTER_NAME skuba cluster status
 }
 
 skuba_node_upgrade() {
@@ -219,7 +219,7 @@ skuba_node_upgrade() {
      _define_node_group "$target"
     local i=0
     for n in $GROUP; do
-        skuba_container "$SKUBA_CLUSTER_NAME" skuba node upgrade \
+        skuba_container "$CLUSTER_NAME" skuba node upgrade \
                         apply --user sles --sudo --target "$n" -v "$DEBUG"
     done
 }

--- a/backend/caasp4os/terraform-os/lbaas-cap.tf
+++ b/backend/caasp4os/terraform-os/lbaas-cap.tf
@@ -1,27 +1,31 @@
 resource "openstack_lb_listener_v2" "uaa_listener" {
   protocol        = "TCP"
   protocol_port   = "2793"
-  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  loadbalancer_id = openstack_lb_loadbalancer_v2.lb.id
   name            = "${var.stack_name}-uaa-listener"
+
+  depends_on = [
+    openstack_lb_loadbalancer_v2.lb
+  ]
 }
 
 resource "openstack_lb_pool_v2" "uaa_pool" {
   name        = "${var.stack_name}-uaa-pool"
   protocol    = "TCP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = "${openstack_lb_listener_v2.uaa_listener.id}"
+  listener_id = openstack_lb_listener_v2.uaa_listener.id
 }
 
 resource "openstack_lb_member_v2" "uaa_member" {
-  count         = "${var.workers}"
-  pool_id       = "${openstack_lb_pool_v2.uaa_pool.id}"
-  address       = "${element(openstack_compute_instance_v2.worker.*.access_ip_v4, count.index)}"
-  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  count         = var.workers
+  pool_id       = openstack_lb_pool_v2.uaa_pool.id
+  address       = element(openstack_compute_instance_v2.worker.*.access_ip_v4, count.index)
+  subnet_id     = openstack_networking_subnet_v2.subnet.id
   protocol_port = 2793
 }
 
 resource "openstack_lb_monitor_v2" "uaa_monitor" {
-  pool_id        = "${openstack_lb_pool_v2.uaa_pool.id}"
+  pool_id        = openstack_lb_pool_v2.uaa_pool.id
   type           = "TCP"
   url_path       = "/healthz"
   expected_codes = 200

--- a/backend/caasp4os/terraform-os/master-instance.tf
+++ b/backend/caasp4os/terraform-os/master-instance.tf
@@ -1,102 +1,112 @@
 data "template_file" "master_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "master_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "master_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "master_register_ibs" {
-  template = "${file("cloud-init/register-ibs.tpl")}"
+  template = file("cloud-init/register-ibs.tpl")
 }
 
 data "template_file" "master_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "master-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.master_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
-    register_ibs    = "${join("\n", data.template_file.master_register_ibs.*.rendered)}"
-    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
-    username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.master_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.master_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
+    register_ibs    = join("\n", data.template_file.master_register_ibs.*.rendered)
+    commands        = join("\n", data.template_file.master_commands.*.rendered)
+    username        = var.username
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "openstack_compute_instance_v2" "master" {
-  count      = "${var.masters}"
+  count      = var.masters
   name       = "caasp-master-${var.stack_name}-${count.index}"
-  image_name = "${var.image_name}"
-  key_pair   = "${var.key_pair}"
+  image_name = var.image_name
+  key_pair   = var.key_pair
 
   depends_on = [
-    "openstack_networking_network_v2.network",
-    "openstack_networking_subnet_v2.subnet",
+    openstack_networking_network_v2.network,
+    openstack_networking_subnet_v2.subnet,
   ]
 
-  flavor_name = "${var.master_size}"
+  flavor_name = var.master_size
 
   network {
-    name = "${var.internal_net}"
+    name = var.internal_net
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.name}",
-    "${openstack_networking_secgroup_v2.master_nodes.name}",
+    openstack_networking_secgroup_v2.common.name,
+    openstack_networking_secgroup_v2.master_nodes.name,
   ]
 
-  user_data = "${data.template_file.master-cloud-init.rendered}"
+  user_data = data.template_file.master-cloud-init.rendered
 }
 
 resource "openstack_networking_floatingip_v2" "master_ext" {
-  count = "${var.masters}"
-  pool  = "${var.external_net}"
+  count = var.masters
+  pool  = var.external_net
 }
 
 resource "openstack_compute_floatingip_associate_v2" "master_ext_ip" {
-  count       = "${var.masters}"
-  floating_ip = "${element(openstack_networking_floatingip_v2.master_ext.*.address, count.index)}"
-  instance_id = "${element(openstack_compute_instance_v2.master.*.id, count.index)}"
+  depends_on = [openstack_compute_instance_v2.master]
+  count = var.masters
+  floating_ip = element(
+    openstack_networking_floatingip_v2.master_ext.*.address,
+    count.index,
+  )
+  instance_id = element(openstack_compute_instance_v2.master.*.id, count.index)
 }
 
 resource "null_resource" "master_wait_cloudinit" {
-  depends_on = ["openstack_compute_instance_v2.master"]
-  count      = "${var.masters}"
+  depends_on = [
+    openstack_compute_instance_v2.master,
+    openstack_compute_floatingip_associate_v2.master_ext_ip
+  ]
+  count      = var.masters
 
   connection {
-    host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
-    user = "${var.username}"
+    host = element(
+      openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip,
+      count.index,
+    )
+    user = var.username
     type = "ssh"
   }
 
@@ -108,13 +118,16 @@ resource "null_resource" "master_wait_cloudinit" {
 }
 
 resource "null_resource" "master_reboot" {
-  depends_on = ["null_resource.master_wait_cloudinit"]
-  count      = "${var.masters}"
+  depends_on = [null_resource.master_wait_cloudinit]
+  count      = var.masters
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+      user = var.username
+      host = element(
+        openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -122,5 +135,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 # wait for ssh ready after reboot
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+

--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -49,7 +49,7 @@ master_size = "m1.xlarge"
 worker_size = "m1.xxlarge"
 
 # Attach persistent volumes to workers
-workers_vol_enabled = 0
+workers_vol_enabled = false
 
 # Size of the worker volumes in GB
 workers_vol_size = 5
@@ -58,8 +58,8 @@ workers_vol_size = 5
 # dnsdomain = "my.domain.com"
 dnsdomain = "#~placeholder_stack~#.#~placeholder_magic_dns~#"
 
-# Set DNS Entry (0 is false, 1 is true)
-dnsentry = 0
+# Set DNS Entry
+dnsentry = false
 
 # define the repositories to use
 # EXAMPLE:

--- a/backend/caasp4os/terraform-os/worker-instance.tf
+++ b/backend/caasp4os/terraform-os/worker-instance.tf
@@ -1,28 +1,28 @@
 data "template_file" "worker_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "worker_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "worker_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
@@ -31,86 +31,97 @@ data "template_file" "worker_register_ibs" {
 }
 
 data "template_file" "worker_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "worker-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.worker_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
-    register_ibs    = "${join("\n", data.template_file.worker_register_ibs.*.rendered)}"
-    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
-    username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.worker_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.worker_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.worker_register_rmt.*.rendered)
+    register_ibs    = join("\n", data.template_file.worker_register_ibs.*.rendered)
+    commands        = join("\n", data.template_file.worker_commands.*.rendered)
+    username        = var.username
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "openstack_blockstorage_volume_v2" "worker_vol" {
-  count = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
-  size  = "${var.workers_vol_size}"
+  count = var.workers_vol_enabled ? var.workers : 0
+  size  = var.workers_vol_size
   name  = "vol_${element(openstack_compute_instance_v2.worker.*.name, count.index)}"
 }
 
 resource "openstack_compute_volume_attach_v2" "worker_vol_attach" {
-  count       = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
-  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
-  volume_id   = "${element(openstack_blockstorage_volume_v2.worker_vol.*.id, count.index)}"
+  count       = var.workers_vol_enabled ? var.workers : 0
+  instance_id = element(openstack_compute_instance_v2.worker.*.id, count.index)
+  volume_id = element(
+    openstack_blockstorage_volume_v2.worker_vol.*.id,
+    count.index,
+  )
 }
 
 resource "openstack_compute_instance_v2" "worker" {
-  count      = "${var.workers}"
+  count      = var.workers
   name       = "caasp-worker-${var.stack_name}-${count.index}"
-  image_name = "${var.image_name}"
-  key_pair   = "${var.key_pair}"
+  image_name = var.image_name
+  key_pair   = var.key_pair
 
   depends_on = [
-    "openstack_networking_network_v2.network",
-    "openstack_networking_subnet_v2.subnet",
+    openstack_networking_network_v2.network,
+    openstack_networking_subnet_v2.subnet,
   ]
 
-  flavor_name = "${var.worker_size}"
+  flavor_name = var.worker_size
 
   network {
-    name = "${var.internal_net}"
+    name = var.internal_net
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.name}",
-    "${openstack_compute_secgroup_v2.secgroup_cap.name}",
+    openstack_networking_secgroup_v2.common.name,
   ]
 
-  user_data = "${data.template_file.worker-cloud-init.rendered}"
+  user_data = data.template_file.worker-cloud-init.rendered
 }
 
 resource "openstack_networking_floatingip_v2" "worker_ext" {
-  count = "${var.workers}"
-  pool  = "${var.external_net}"
+  count = var.workers
+  pool  = var.external_net
 }
 
 resource "openstack_compute_floatingip_associate_v2" "worker_ext_ip" {
-  count       = "${var.workers}"
-  floating_ip = "${element(openstack_networking_floatingip_v2.worker_ext.*.address, count.index)}"
-  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
+  depends_on = [openstack_compute_instance_v2.worker]
+  count = var.workers
+  floating_ip = element(
+    openstack_networking_floatingip_v2.worker_ext.*.address,
+    count.index,
+  )
+  instance_id = element(openstack_compute_instance_v2.worker.*.id, count.index)
 }
 
 resource "null_resource" "worker_wait_cloudinit" {
-  depends_on = ["openstack_compute_instance_v2.worker"]
-  count      = "${var.workers}"
+  depends_on = [
+    openstack_compute_instance_v2.worker,
+    openstack_compute_floatingip_associate_v2.worker_ext_ip,
+  ]
+  count      = var.workers
 
   connection {
-    host    = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
-    user    = "${var.username}"
-    type    = "ssh"
-    timeout = "10m"
+    host = element(
+      openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip,
+      count.index,
+    )
+    user = var.username
+    type = "ssh"
   }
 
   provisioner "remote-exec" {
@@ -121,13 +132,16 @@ resource "null_resource" "worker_wait_cloudinit" {
 }
 
 resource "null_resource" "worker_reboot" {
-  depends_on = ["null_resource.worker_wait_cloudinit"]
-  count      = "${var.workers}"
+  depends_on = [null_resource.worker_wait_cloudinit]
+  count      = var.workers
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+      user = var.username
+      host = element(
+        openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -135,5 +149,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 # wait for ssh ready after reboot
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+


### PR DESCRIPTION
CaaSP 4.1 and above uses Terraform 0.12, so we need to port
the templates accordingly to match that Terraform version.