### PR TITLE
Fix security group handling for caasp4os backend

### DIFF
--- a/backend/caasp4os/terraform-os/master-instance.tf
+++ b/backend/caasp4os/terraform-os/master-instance.tf
@@ -72,8 +72,8 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   security_groups = [
-    openstack_networking_secgroup_v2.common.name,
-    openstack_networking_secgroup_v2.master_nodes.name,
+    openstack_networking_secgroup_v2.common.id,
+    openstack_networking_secgroup_v2.master_nodes.id,
   ]
 
   user_data = data.template_file.master-cloud-init.rendered

--- a/backend/caasp4os/terraform-os/security-groups-cap.tf
+++ b/backend/caasp4os/terraform-os/security-groups-cap.tf
@@ -1,60 +1,84 @@
-resource "openstack_compute_secgroup_v2" "secgroup_cap" {
+resource "openstack_networking_secgroup_v2" "secgroup_cap" {
   name        = "${var.stack_name}-cap_lb_secgroup"
   description = "CAP security group"
+}
 
-  rule {
-    from_port   = 80
-    to_port     = 80
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 2222
-    to_port     = 2222
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "port_2222" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 2222
+  port_range_max    = 2222
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 2793
-    to_port     = 2793
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "port_2793" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 2793
+  port_range_max    = 2793
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 4443
-    to_port     = 4443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "port_4443" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 4443
+  port_range_max    = 4443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 8443
-    to_port     = 8443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "port_7443" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 7443
+  port_range_max    = 7443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 7443
-    to_port     = 7443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "port_8443" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8443
+  port_range_max    = 8443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
+}
 
-  rule {
-    from_port   = 20000
-    to_port     = 20008
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "tcp_high" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10000
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_cap.id
 }

--- a/backend/caasp4os/terraform-os/storage-instance.tf
+++ b/backend/caasp4os/terraform-os/storage-instance.tf
@@ -99,8 +99,8 @@ resource "openstack_compute_instance_v2" "storage" {
   }
 
   security_groups = [
-    openstack_compute_secgroup_v2.storage.name,
-    openstack_networking_secgroup_v2.common.name,
+    openstack_networking_secgroup_v2.storage.id,
+    openstack_networking_secgroup_v2.common.id
   ]
 
   user_data = data.template_file.storage-cloud-init.rendered
@@ -174,79 +174,29 @@ resource "null_resource" "storage_config" {
   }
 }
 
-resource "openstack_compute_secgroup_v2" "storage" {
+resource "openstack_networking_secgroup_v2" "storage" {
   name        = "caasp-storage-${var.stack_name}"
   description = "Basic security group"
+}
 
-  rule {
-    from_port   = -1
-    to_port     = -1
-    ip_protocol = "icmp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "storage_tcp_high" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1024
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.storage.id
+}
 
-  rule {
-    from_port   = 22
-    to_port     = 22
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 111
-    to_port     = 111
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 2049
-    to_port     = 2049
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 20048
-    to_port     = 20048
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 33904
-    to_port     = 33904
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 111
-    to_port     = 111
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 2049
-    to_port     = 2049
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 20048
-    to_port     = 20048
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 33904
-    to_port     = 33904
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "storage_udp_high" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 1024
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.storage.id
 }
 
 output "ip_storage_int" {

--- a/backend/caasp4os/terraform-os/worker-instance.tf
+++ b/backend/caasp4os/terraform-os/worker-instance.tf
@@ -87,7 +87,8 @@ resource "openstack_compute_instance_v2" "worker" {
   }
 
   security_groups = [
-    openstack_networking_secgroup_v2.common.name,
+    openstack_networking_secgroup_v2.common.id,
+    openstack_networking_secgroup_v2.secgroup_cap.id
   ]
 
   user_data = data.template_file.worker-cloud-init.rendered

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -45,7 +45,7 @@ fi
 
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
 
-if [ "$SCF_OPERATOR" == true ]; then
+if [ "${SCF_OPERATOR}" == "true" ]; then
     rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
        imagelist.txt requirements.lock  requirements.yaml
 fi


### PR DESCRIPTION
There were several bugs in this code:
* it was using a mix of nova compute and neutron networking security
  groups, that is not very stable and can cause races. use networking
  rules consistently.
* it was using 'name' for assigning security groups, which fails
  if there are duplicates. better use 'id's as those are ids
* simplify rules a bit
* fix missing cap-rules assignment for accessing cf endpoint.