### PR TITLE
Add kubecf module, separate kubecf and scf code, provide compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,19 @@ kubecf-build-stemcell: ##@kubecf Build stemcell for KubeCF
 	$(MAKE) -C modules/kubecf stemcell_build
 
 # scf-only targets:
+ifeq "$(SCF_OPERATOR)" "true"
+scf-build: kubecf-build
+scf-clean: kubecf-clean
+scf: kubecf
+scf-chart: kubecf-chart
+scf-gen-config: kubecf-gen-config
+scf-install: kubecf-install
+scf-upgrade: kubecf-upgrade
+scf-login: kubecf-login
+scf-minibroker: kubecf-minibroker
+scf-purge: kubecf-purge
+scf-build-stemcell: kubecf-build-stemcell
+else
 .PHONY: scf-build
 scf-build: ##@scf Build chart from source and install CF
 	$(MAKE) -C modules/scf build-scf-from-source
@@ -253,6 +266,7 @@ scf-purge: ##@scf Purge all apps, buildpacks and services from CF
 .PHONY: scf-build-stemcell
 scf-build-stemcell: ##@scf Build stemcell
 	$(MAKE) -C modules/scf stemcell_build
+endif
 
 # stratos-only targets:
 .PHONY: stratos

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ force-clean: buildir clean
 
 .PHONY: all
 all: ## Alias for `make k8s scf scf-login`
-all: scf-deploy scf-login # TODO remove scf-deploy
+all: k8s kubecf kubecf-login # TODO remove scf-deploy
 
 # kind targets:
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ buildir:
 # General targets (Public)
 .PHONY: clean
 clean: ##@STATES Delete cluster of type $BACKEND and location build$CLUSTER_NAME
-clean: scf-clean # first scf-clean to delete PVCs, DNS entries, etc
+clean: kubecf-clean # first kubecf-clean to delete PVCs, DNS entries, etc
 	$(MAKE) -C backend/$(BACKEND) clean
 
 .PHONY: k8s
@@ -159,6 +159,53 @@ module-experimental-eirinifs:
 .PHONY: module-experimental-eirini_release
 module-experimental-eirini_release:
 	$(MAKE) -C modules/experimental eirini_release
+
+# kubecf-only targets:
+.PHONY: kubecf-build
+kubecf-build: ##@kubecf Build chart from source and install KubeCF
+	$(MAKE) -C modules/kubecf build-from-source
+	$(MAKE) kubecf-gen-config
+	$(MAKE) -C modules/kubecf install
+
+.PHONY: kubecf-clean
+kubecf-clean: ##@kubecf Only delete installation of KubeCF & related files
+	$(MAKE) -C modules/kubecf clean
+
+.PHONY: sc	f
+kubecf: ##@STATES Delete if exists then deploy KubeCF in cluster
+	$(MAKE) -C modules/kubecf
+
+.PHONY: kubecf-chart
+kubecf-chart: ##@kubecf Only obtain KubeCF chart, by file or download
+	$(MAKE) -C modules/kubecf chart
+
+.PHONY: kubecf-gen-config
+kubecf-gen-config: ##@kubecf Only generate KubeCF config yamls
+	$(MAKE) -C modules/kubecf gen-config
+
+.PHONY: kubecf-install
+kubecf-install: ##@kubecf Only install KubeCF
+	$(MAKE) -C modules/kubecf install
+
+.PHONY: kubecf-upgrade
+kubecf-upgrade: ##@kubecf Only upgrade KubeCF
+	$(MAKE) -C modules/kubecf upgrade
+
+.PHONY: kubecf-login
+kubecf-login: ##@kubecf Only perform cf login against deployed KubeCF
+	$(MAKE) -C modules/kubecf login
+
+.PHONY: kubecf-minibroker
+kubecf-minibroker: ##@kubecf Deploy minibroker & services on KubeCF
+	$(MAKE) -C modules/kubecf minibroker
+
+.PHONY: kubecf-purge
+kubecf-purge: ##@kubecf Purge all apps, buildpacks and services from KubeCF
+	$(MAKE) -C modules/kubecf purge
+
+.PHONY: kubecf-build-stemcell
+kubecf-build-stemcell: ##@kubecf Build stemcell for KubeCF
+	$(MAKE) -C modules/kubecf stemcell_build
 
 # scf-only targets:
 .PHONY: scf-build

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,11 @@ kubecf-build-stemcell: ##@kubecf Build stemcell for KubeCF
 	$(MAKE) -C modules/kubecf stemcell_build
 
 # scf-only targets:
+
+# Provide compatibility with kubecf by redirecting:
+#    SCF_OPERATOR=true make scf*
+# to:
+#    make kubecf
 ifeq "$(SCF_OPERATOR)" "true"
 scf-build: kubecf-build
 scf-clean: kubecf-clean

--- a/Makefile
+++ b/Makefile
@@ -161,13 +161,6 @@ module-experimental-eirini_release:
 	$(MAKE) -C modules/experimental eirini_release
 
 # scf-only targets:
-.PHONY: scf-deploy
-scf-deploy:
-	@echo 'WARNING: target deprecated. Please use `make k8s/kubeconfig` and then `make scf` instead.'
-	@echo 'Kindly waiting for 20s…'; sleep 20
-	$(MAKE) clean buildir
-	$(MAKE) k8s kubeconfig scf
-
 .PHONY: scf-build
 scf-build: ##@scf Build chart from source and install CF
 	$(MAKE) -C modules/scf build-scf-from-source

--- a/include/defaults_global.sh
+++ b/include/defaults_global.sh
@@ -3,8 +3,6 @@
 # Global options
 ################
 
-export SCF_REPO="${SCF_REPO:-https://github.com/SUSE/scf}"
-export SCF_BRANCH="${SCF_BRANCH:-develop}"
 export DOCKER_REGISTRY="${DOCKER_REGISTRY:-registry.suse.com}"
 export DOCKER_ORG="${DOCKER_ORG:-cap}"
 

--- a/include/func.sh
+++ b/include/func.sh
@@ -298,38 +298,38 @@ external_dns_annotate_uaa() {
             "external-dns.alpha.kubernetes.io/hostname=uaa.${domain}, *.uaa.${domain}"
 }
 
+external_dns_annotate_kubecf() {
+    local ns=$1;shift
+    local domain=$1;shift
+    # for kubecf
+    kubectl annotate svc router-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=${domain}, *.${domain}"
+    if [[ "${ENABLE_EIRINI}" == true ]] ; then
+        kubectl annotate svc eirinix-ssh-proxy \
+                -n "$ns" \
+                "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
+    else
+        kubectl annotate svc ssh-proxy-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
+    fi
+    kubectl annotate svc tcp-router-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=*.tcp.${domain}, tcp.${domain}"
+}
 
 external_dns_annotate_scf() {
     local ns=$1;shift
     local domain=$1;shift
-    if [ "${SCF_OPERATOR}" == "true" ]; then
-        # for kubecf
-        kubectl annotate svc router-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=${domain}, *.${domain}"
-        if [[ "${ENABLE_EIRINI}" == true ]] ; then
-            kubectl annotate svc eirinix-ssh-proxy \
-                    -n "$ns" \
-                    "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
-        else
-            kubectl annotate svc ssh-proxy-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
-        fi
-        kubectl annotate svc tcp-router-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=*.tcp.${domain}, tcp.${domain}"
-    else
-        # for scf
-        kubectl annotate svc router-gorouter-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=${domain}, *.${domain}"
-        kubectl annotate svc diego-ssh-ssh-proxy-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
-        kubectl annotate svc tcp-router-tcp-router-public \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=*.tcp.${domain}, tcp.${domain}"
-    fi
+    # for scf
+    kubectl annotate svc router-gorouter-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=${domain}, *.${domain}"
+    kubectl annotate svc diego-ssh-ssh-proxy-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
+    kubectl annotate svc tcp-router-tcp-router-public \
+            -n "$ns" \
+            "external-dns.alpha.kubernetes.io/hostname=*.tcp.${domain}, tcp.${domain}"
 }
-

--- a/modules/kubecf/Makefile
+++ b/modules/kubecf/Makefile
@@ -1,0 +1,58 @@
+.DEFAULT_GOAL := all
+
+.PHONY: clean
+clean:
+	./clean.sh
+
+.PHONY: chart
+chart:
+	./chart.sh
+
+.PHONY: gen-config
+gen-config:
+	./gen_config.sh
+
+.PHONY: install
+install:
+	./install.sh
+
+.PHONY: login
+login:
+	./login.sh
+
+.PHONY: purge
+purge:
+	./purge.sh
+
+.PHONY: all
+all: clean chart gen-config install
+
+## one-offs:
+
+.PHONY: precheck
+precheck:
+	./precheck.sh
+
+.PHONY: brats-setup
+scf-brats-setup:
+	./brats_setup.sh
+
+.PHONY: upgrade
+upgrade:
+	./upgrade.sh
+
+.PHONY: build-from-source
+build-from-source:
+	./build.sh
+
+.PHONY: klog
+klog:
+	./klog.sh
+
+.PHONY: stemcell_build
+stemcell_build:
+	./stemcell_build.sh
+
+.PHONY: minibroker
+minibroker:
+	./minibroker.sh

--- a/modules/kubecf/brats_setup.sh
+++ b/modules/kubecf/brats_setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+. ../../include/common.sh
+. .envrc
+
+
+domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
+aux_external_ips=("$(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address')")
+external_ips+="\"$public_ip\""
+for (( i=0; i < ${#aux_external_ips[@]}; i++ )); do
+    external_ips+=", \"${aux_external_ips[$i]}\""
+done
+
+cat > nginx_proxy_deployment.yaml <<EOF
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx-proxy-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx-proxy
+  template:
+    metadata:
+      labels:
+        app: nginx-proxy
+    spec:
+      containers:
+      - name: nginx-proxy
+        image: quay.io/dtan4/nginx-basic-auth-proxy
+        ports:
+        - containerPort: 80
+        env:
+        - name: SERVER_NAME
+          value: "${domain}" # This should match the caasp master's floating ip
+        - name: BASIC_AUTH_USERNAME
+          value: "username"
+        - name: BASIC_AUTH_PASSWORD
+          value: "password"
+        - name: PROXY_PASS
+          value: "https://s3.amazonaws.com/" # Change this to "https://download.opensuse.org/" for OBS hosted dependencies
+        - name: PORT
+          value: "80"
+EOF
+
+kubectl apply -f nginx_proxy_deployment.yaml || true
+
+cat > nginx_proxy_service.yaml <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-proxy
+  labels:
+    run: nginx-proxy
+spec:
+  externalIPs: [${external_ips}]  # This should match the caasp master's "internal" ip (not the floating one)
+  ports:
+  - port: 9002
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: nginx-proxy
+EOF
+
+kubectl apply -f nginx_proxy_service.yaml || true
+
+cat > securitygroup.json <<EOF
+[
+        {
+                "destination": "${public_ip}",
+                "ports": "9002",
+                "protocol": "tcp"
+        }
+]
+EOF
+
+if [ -n "$EKCP_PROXY" ]; then
+    export https_proxy=socks5://127.0.0.1:${KUBEPROXY_PORT}
+fi
+
+cf create-security-group nginx_proxy securitygroup.json
+cf bind-running-security-group nginx_proxy
+cf bind-staging-security-group nginx_proxy
+
+ok "Configuration for BRATS finished"

--- a/modules/kubecf/build.sh
+++ b/modules/kubecf/build.sh
@@ -16,21 +16,10 @@ else
 fi
 
 GIT_HEAD=$(git log --pretty=format:'%h' -n 1)
-if [ "$SCF_OPERATOR" == "true" ]; then
-    rm -rfv bazel-bin/deploy/helm/kubecf/* || true
-    bazel build //deploy/helm/kubecf
-    tar -xvf bazel-bin/deploy/helm/kubecf/kubecf.tgz -C "$BUILD_DIR"
-    SCF_CHART=kubecf-"$GIT_HEAD"
-else
-    sed -i 's|exit 1||' make/kube-dist || true
-    sed -i 's|exit 1||' make/bundle-dist || true
-    docker exec "$DOCKER_OPTS" \
-    -ti "$CLUSTER_NAME"-control-plane \
-    /bin/bash -exc ' apt-get update && apt-get install -y ruby git wget make; cd /code/scf && chmod -R 777 src && source .envrc && ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
-    cp -rfv output/*.zip ../
-    unzip -o ./*.zip
-    SCF_CHART=scf-"$GIT_HEAD"
-fi
+rm -rfv bazel-bin/deploy/helm/kubecf/* || true
+bazel build //deploy/helm/kubecf
+tar -xvf bazel-bin/deploy/helm/kubecf/kubecf.tgz -C "$BUILD_DIR"
+SCF_CHART=kubecf-"$GIT_HEAD"
 popd || exit
 
 # save SCF_CHART on cap-values configmap

--- a/modules/kubecf/build.sh
+++ b/modules/kubecf/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+if [ -z "$SCF_LOCAL" ]; then
+    [ ! -d "scf" ] && git clone --recurse-submodules "$SCF_REPO" scf
+    git reset --hard "$SCF_BRANCH"
+    git submodule sync --recursive && \
+    git submodule update --init --recursive && \
+    git submodule foreach --recursive "git checkout . && git reset --hard && git clean -dffx"
+    pushd scf || exit
+else
+    pushd "$SCF_LOCAL" || exit
+fi
+
+GIT_HEAD=$(git log --pretty=format:'%h' -n 1)
+if [ "$SCF_OPERATOR" == "true" ]; then
+    rm -rfv bazel-bin/deploy/helm/kubecf/* || true
+    bazel build //deploy/helm/kubecf
+    tar -xvf bazel-bin/deploy/helm/kubecf/kubecf.tgz -C "$BUILD_DIR"
+    SCF_CHART=kubecf-"$GIT_HEAD"
+else
+    sed -i 's|exit 1||' make/kube-dist || true
+    sed -i 's|exit 1||' make/bundle-dist || true
+    docker exec "$DOCKER_OPTS" \
+    -ti "$CLUSTER_NAME"-control-plane \
+    /bin/bash -exc ' apt-get update && apt-get install -y ruby git wget make; cd /code/scf && chmod -R 777 src && source .envrc && ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
+    cp -rfv output/*.zip ../
+    unzip -o ./*.zip
+    SCF_CHART=scf-"$GIT_HEAD"
+fi
+popd || exit
+
+# save SCF_CHART on cap-values configmap
+kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'

--- a/modules/kubecf/chart.sh
+++ b/modules/kubecf/chart.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+rm -rf helm chart scf_chart_url suse kubecf
+
+if [ -z "$SCF_CHART" ] && [ -z "$SCF_HELM_VERSION" ]; then
+    warn "No chart url given - using latest public release from GH"
+    if  [ "${SCF_OPERATOR}" != "true" ]; then
+        SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
+    else
+        SCF_CHART=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/kubecf/releases/latest | grep "browser_download_url.*bundle.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
+    fi
+fi
+
+if [ -n "$SCF_HELM_VERSION" ]; then
+    HELM_REPO="${SCF_HELM_REPO:-https://kubernetes-charts.suse.com/}"
+    HELM_REPO_NAME="${SCF_HELM_REPO_NAME:-suse}"
+    info "Grabbing $SCF_HELM_VERSION from $HELM_REPO"
+
+    helm_init_client
+    helm repo add "$HELM_REPO_NAME" $HELM_REPO
+    helm repo update
+
+    helm fetch "$HELM_REPO_NAME"/cf --version $SCF_HELM_VERSION
+    helm fetch "$HELM_REPO_NAME"/uaa --version $SCF_HELM_VERSION
+
+    mkdir -p charts/helm
+    tar xvf cf-*.tgz -C charts/helm
+    tar xvf uaa-*.tgz -C charts/helm
+    pushd charts || exit
+        VERSION=$(yq r helm/cf/Chart.yaml version)
+        API_VERSION=$(yq r helm/cf/Chart.yaml apiVersion)
+
+        if [ "${API_VERSION}" == "v1" ]; then
+            API_VERSION=$(yq r helm/cf/Chart.yaml scfVersion)
+        fi
+
+        if [ -z "$VERSION" ]; then
+            err "No version found from the chart"
+            exit 1
+        fi
+
+        if [ -z "$API_VERSION" ]; then
+            err "No api version found from the chart"
+            exit 1
+        fi
+        info "Producing bundle for $API_VERSION - $VERSION"
+        tar cvzf ../scf-sle-${API_VERSION}.tgz *
+        zip -r9 ../scf-sle-${API_VERSION}.zip -- *
+        export SCF_CHART=$PWD/../scf-sle-${API_VERSION}.zip
+    popd || exit
+fi
+
+rm -rf scf_chart_url || true
+
+if echo "$SCF_CHART" | grep -q "http"; then
+    wget "$SCF_CHART" -O chart
+    echo "$SCF_CHART" > scf_chart_url
+else
+    cp -rfv "$SCF_CHART" chart
+fi
+
+if echo "$SCF_CHART" | grep -q "tgz"; then
+    tar -xvf chart -C ./
+else
+    unzip -o chart
+fi
+
+if  [ "${SCF_OPERATOR}" == "true" ]; then
+    if echo "$SCF_CHART" | grep -q "bundle"; then
+        tar xvzf cf-operator*.tgz
+        tar xvzf kubecf*.tgz
+    fi
+    cp -rfv kubecf*/* ./
+fi
+
+# save SCF_CHART on cap-values configmap
+kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'
+
+ok "Chart uncompressed"

--- a/modules/kubecf/chart.sh
+++ b/modules/kubecf/chart.sh
@@ -8,11 +8,7 @@ rm -rf helm chart scf_chart_url suse kubecf
 
 if [ -z "$SCF_CHART" ] && [ -z "$SCF_HELM_VERSION" ]; then
     warn "No chart url given - using latest public release from GH"
-    if  [ "${SCF_OPERATOR}" != "true" ]; then
-        SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
-    else
-        SCF_CHART=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/kubecf/releases/latest | grep "browser_download_url.*bundle.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
-    fi
+    SCF_CHART=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/kubecf/releases/latest | grep "browser_download_url.*bundle.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
 fi
 
 if [ -n "$SCF_HELM_VERSION" ]; then
@@ -69,13 +65,11 @@ else
     unzip -o chart
 fi
 
-if  [ "${SCF_OPERATOR}" == "true" ]; then
-    if echo "$SCF_CHART" | grep -q "bundle"; then
-        tar xvzf cf-operator*.tgz
-        tar xvzf kubecf*.tgz
-    fi
-    cp -rfv kubecf*/* ./
+if echo "$SCF_CHART" | grep -q "bundle"; then
+    tar xvzf cf-operator*.tgz
+    tar xvzf kubecf*.tgz
 fi
+cp -rfv kubecf*/* ./
 
 # save SCF_CHART on cap-values configmap
 kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -59,4 +59,4 @@ if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.da
             -p '[{"op": "remove", "path": "/data/services"}]'
 fi
 
-ok "Cleaned up scf from the k8s cluster"
+ok "Cleaned up KubeCF from the k8s cluster"

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc || exit 0
+
+# if no kubeconfig, no cf. Exit
+[ -f "$KUBECONFIG" ] || exit 0
+
+if [ "$EMBEDDED_UAA" != "true" ]; then
+    if helm_ls 2>/dev/null | grep -qi susecf-uaa ; then
+        helm_delete susecf-uaa
+    fi
+    if kubectl get namespaces 2>/dev/null | grep -qi uaa ; then
+        kubectl delete --ignore-not-found namespace uaa
+    fi
+fi
+
+if helm_ls 2>/dev/null | grep -qi susecf-scf ; then
+    helm_delete susecf-scf --namespace scf
+fi
+if kubectl get namespaces 2>/dev/null | grep -qi scf ; then
+    kubectl delete --ignore-not-found namespace scf
+fi
+
+if kubectl get psp 2>/dev/null | grep -qi susecf-scf ; then
+    kubectl delete --ignore-not-found psp susecf-scf-default
+fi
+
+if helm_ls 2>/dev/null | grep -qi cf-operator ; then
+    helm_delete cf-operator --namespace cf-operator
+fi
+if kubectl get namespaces 2>/dev/null | grep -qi cf-operator ; then
+    kubectl delete --ignore-not-found namespace cf-operator
+fi
+
+if [[ "$ENABLE_EIRINI" == true ]] ; then
+    if kubectl get namespaces 2>/dev/null | grep -qi eirini ; then
+        kubectl delete --ignore-not-found namespace eirini
+    fi
+    if helm_ls 2>/dev/null | grep -qi metrics-server ; then
+        helm_delete metrics-server
+    fi
+fi
+
+rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
+
+if [ "${SCF_OPERATOR}" == "true" ]; then
+    rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
+       imagelist.txt requirements.lock  requirements.yaml
+fi
+
+# delete SCF_CHART on cap-values configmap
+if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.chart // empty')" ]]; then
+    kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/chart"}]'
+fi
+
+# delete SCF_SERVICES on cap-values configmap
+if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.services // empty')" ]]; then
+    kubectl patch -n kube-system configmap cap-values --type json \
+            -p '[{"op": "remove", "path": "/data/services"}]'
+fi
+
+ok "Cleaned up scf from the k8s cluster"

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -45,10 +45,8 @@ fi
 
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
 
-if [ "${SCF_OPERATOR}" == "true" ]; then
-    rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
-       imagelist.txt requirements.lock  requirements.yaml
-fi
+rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
+   imagelist.txt requirements.lock  requirements.yaml
 
 # delete SCF_CHART on cap-values configmap
 if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.chart // empty')" ]]; then

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# SCF options
+#############
+
+# scf-chart revelant:
+
+CHART_URL="${CHART_URL:-}" # FIXME deprecated, used in SCF_CHART
+SCF_CHART="${SCF_CHART:-$CHART_URL}"
+
+SCF_HELM_VERSION="${SCF_HELM_VERSION:-}"
+OPERATOR_CHART_URL="${OPERATOR_CHART_URL:-latest}"
+
+# scf-gen-config relevant:
+
+SCF_SERVICES="${SCF_SERVICES:-lb}" # lb, ingress
+GARDEN_ROOTFS_DRIVER="${GARDEN_ROOTFS_DRIVER:-overlay-xfs}"
+DIEGO_SIZING="${DIEGO_SIZING:-$SIZING}"
+STORAGECLASS="${STORAGECLASS:-persistent}"
+AUTOSCALER="${AUTOSCALER:-false}"
+
+EMBEDDED_UAA="${EMBEDDED_UAA:-false}"
+
+HA="${HA:-false}"
+if [ "$HA" = "true" ]; then
+    SIZING="${SIZING:-2}"
+else
+    SIZING="${SIZING:-1}"
+fi
+
+UAA_UPGRADE="${UAA_UPGRADE:-true}"
+
+OVERRIDE="${OVERRIDE:-}"
+CONFIG_OVERRIDE="${CONFIG_OVERRIDE:-$OVERRIDE}"
+
+BRAIN_VERBOSE="${BRAIN_VERBOSE:-false}"
+BRAIN_INORDER="${BRAIN_INORDER:-false}"
+BRAIN_INCLUDE="${BRAIN_INCLUDE:-}"
+BRAIN_EXCLUDE="${BRAIN_EXCLUDE:-}"
+
+CATS_NODES="${CATS_NODES:-1}"
+CATS_FLAKE_ATTEMPTS="${CATS_FLAKE_ATTEMPTS:-5}"
+CATS_TIMEOUT_SCALE="${CATS_TIMEOUT_SCALE:-3.0}"
+
+
+# scf-build relevant:
+
+SCF_LOCAL="${SCF_LOCAL:-}"
+
+# relevant to several:
+
+SCF_OPERATOR="${SCF_OPERATOR:-false}"
+HELM_VERSION="${HELM_VERSION:-v3.1.1}"

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -51,3 +51,6 @@ SCF_LOCAL="${SCF_LOCAL:-}"
 
 SCF_OPERATOR="${SCF_OPERATOR:-false}"
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
+
+SCF_REPO="${SCF_REPO:-https://github.com/cloudfoundry-incubator/kubecf}"
+SCF_BRANCH="${SCF_BRANCH:-master}"

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -49,7 +49,6 @@ SCF_LOCAL="${SCF_LOCAL:-}"
 
 # relevant to several:
 
-SCF_OPERATOR="${SCF_OPERATOR:-true}"
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 
 SCF_REPO="${SCF_REPO:-https://github.com/cloudfoundry-incubator/kubecf}"

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# SCF options
-#############
+# KUBECF options
+################
 
-# scf-chart revelant:
+# kubecf-chart revelant:
 
 CHART_URL="${CHART_URL:-}" # FIXME deprecated, used in SCF_CHART
 SCF_CHART="${SCF_CHART:-$CHART_URL}"
@@ -11,7 +11,7 @@ SCF_CHART="${SCF_CHART:-$CHART_URL}"
 SCF_HELM_VERSION="${SCF_HELM_VERSION:-}"
 OPERATOR_CHART_URL="${OPERATOR_CHART_URL:-latest}"
 
-# scf-gen-config relevant:
+# kubecf-gen-config relevant:
 
 SCF_SERVICES="${SCF_SERVICES:-lb}" # lb, ingress
 GARDEN_ROOTFS_DRIVER="${GARDEN_ROOTFS_DRIVER:-overlay-xfs}"
@@ -43,13 +43,13 @@ CATS_FLAKE_ATTEMPTS="${CATS_FLAKE_ATTEMPTS:-5}"
 CATS_TIMEOUT_SCALE="${CATS_TIMEOUT_SCALE:-3.0}"
 
 
-# scf-build relevant:
+# kubecf-build relevant:
 
 SCF_LOCAL="${SCF_LOCAL:-}"
 
 # relevant to several:
 
-SCF_OPERATOR="${SCF_OPERATOR:-false}"
+SCF_OPERATOR="${SCF_OPERATOR:-true}"
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 
 SCF_REPO="${SCF_REPO:-https://github.com/cloudfoundry-incubator/kubecf}"

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -5,7 +5,7 @@
 . .envrc
 
 
-info "Generating SCF config values"
+info "Generating KubeCF config values"
 
 kubectl patch -n kube-system configmap cap-values -p $'data:\n services: "'$SCF_SERVICES'"'
 services="$SCF_SERVICES"
@@ -106,4 +106,4 @@ cat >> scf-config-values.yaml <<EOF
 ${CONFIG_OVERRIDE}
 EOF
 
-ok "SCF config values generated"
+ok "KubeCF config values generated"

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+
+info "Generating SCF config values"
+if [ "$SCF_OPERATOR" != true ]; then
+    if [ "${DEFAULT_STACK}" = "from_chart" ]; then
+        if [[ "$HELM_VERSION" == v3* ]];
+        then
+          DEFAULT_STACK=$(helm show values helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+        else
+          DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+        fi
+        export DEFAULT_STACK
+    fi
+fi
+
+kubectl patch -n kube-system configmap cap-values -p $'data:\n services: "'$SCF_SERVICES'"'
+services="$SCF_SERVICES"
+domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
+array_external_ips=()
+while IFS='' read -r line; do array_external_ips+=("$line");
+done < <(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address')
+external_ips+="\"$public_ip\""
+for (( i=0; i < ${#array_external_ips[@]}; i++ )); do
+external_ips+=", \"${array_external_ips[$i]}\""
+done
+
+VALUES=
+if [ "$ENABLE_EIRINI" = true ] ; then
+  AUTH="rbac"
+else
+  AUTH="rbac"
+  VALUES=$(cat <<'END_HEREDOC'
+sizing:
+  cc_uploader:
+    capabilities: ["SYS_RESOURCE"]
+  diego_api:
+    capabilities: ["SYS_RESOURCE"]
+  diego_brain:
+    capabilities: ["SYS_RESOURCE"]
+  diego_ssh:
+    capabilities: ["SYS_RESOURCE"]
+  nats:
+    capabilities: ["SYS_RESOURCE"]
+  router:
+    capabilities: ["SYS_RESOURCE"]
+  routing_api:
+    capabilities: ["SYS_RESOURCE"]
+END_HEREDOC
+)
+
+fi
+
+if [ "${SCF_OPERATOR}" == "true" ]; then
+
+
+if [ "$services" == ingress ]; then
+INGRESS_BLOCK="ingress:
+    enabled: true
+    tls:
+      crt: ~
+      key: ~
+    annotations: {}
+    labels: {}
+"
+else
+INGRESS_BLOCK=''
+fi
+
+cat > scf-config-values.yaml <<EOF
+system_domain: $domain
+
+features:
+  eirini:
+    enabled: ${ENABLE_EIRINI}
+  autoscaler:
+    enabled: ${AUTOSCALER}
+  ${INGRESS_BLOCK}
+
+kube:
+  service_cluster_ip_range: 0.0.0.0/0
+  pod_cluster_ip_range: 0.0.0.0/0
+
+  registry:
+    hostname: "${DOCKER_REGISTRY}"
+    username: "${DOCKER_USERNAME}"
+    password: "${DOCKER_PASSWORD}"
+  organization: "${DOCKER_ORG}"
+
+high_availability: ${HA}
+
+testing:
+  brain_tests:
+    enabled: true
+  cf_acceptance_tests:
+    enabled: true
+  smoke_tests:
+    enabled: true
+  sync_integration_tests:
+    enabled: true
+properties:
+  acceptance-tests:
+    acceptance-tests:
+      acceptance_tests:
+        timeout_scale: ${CATS_TIMEOUT_SCALE}
+        ginkgo:
+          slow_spec_threshold: 300
+          nodes: ${CATS_NODES}
+          flake_attempts: ${CATS_FLAKE_ATTEMPTS}
+  brain-tests:
+    acceptance-tests-brain:
+      acceptance_tests_brain:
+        verbose: "${BRAIN_VERBOSE}"
+        in_order: "${BRAIN_INORDER}"
+        include: "${BRAIN_INCLUDE}"
+        exclude: "${BRAIN_EXCLUDE}"
+EOF
+
+if [ "${services}" == "lb" ]; then
+    cat >> scf-config-values.yaml <<EOF
+#  External endpoints are created for the instance groups only if
+#  features.ingress.enabled is false.
+services:
+  router:
+    type: LoadBalancer
+    externalIPs: [${external_ips}]
+  ssh-proxy:
+    type: LoadBalancer
+    externalIPs: [${external_ips}]
+  tcp-router:
+    type: LoadBalancer
+    externalIPs: [${external_ips}]
+    port_range:
+      start: 20000
+      end: 20008
+EOF
+fi
+
+# CONFIG_OVERRIDE last, to actually override
+cat >> scf-config-values.yaml <<EOF
+${CONFIG_OVERRIDE}
+EOF
+
+else
+# SCF_OPERATOR != true
+
+cat > scf-config-values.yaml <<EOF
+env:
+  # Enter the domain you created for your CAP cluster
+  DOMAIN: "${domain}"
+  NGINX_MAX_REQUEST_BODY_SIZE: 4000
+  EIRINI_PERSI_PLANS: |
+      - id: "default"
+        name: "default"
+        description: "Eirini persistence broker"
+        free: true
+        kube_storage_class: "${STORAGECLASS}"
+        default_size: "2Gi"
+
+  # UAA host and port
+  UAA_HOST: "uaa.${domain}"
+  UAA_PORT: 2793
+  DEFAULT_STACK: "${DEFAULT_STACK}"
+  GARDEN_ROOTFS_DRIVER: "${GARDEN_ROOTFS_DRIVER}"
+  KUBE_CSR_AUTO_APPROVAL: true
+
+${CONFIG_OVERRIDE}
+
+${VALUES}
+enable:
+  eirini: ${ENABLE_EIRINI}
+  autoscaler: ${AUTOSCALER}
+
+config:
+  HA: ${HA}
+
+EOF
+if [ "${HA}" != "true" ]; then
+cat >> scf-config-values.yaml <<EOF
+sizing:
+  uaa:
+    count: ${SIZING}
+  tcp_router:
+    count: ${SIZING}
+  syslog_scheduler:
+    count: ${SIZING}
+  adapter:
+    count: ${SIZING}
+  api_group:
+    count: ${SIZING}
+  autoscaler_actors:
+    count: 1
+  autoscaler_api:
+    count: ${SIZING}
+  autoscaler_metrics:
+    count: ${SIZING}
+  autoscaler_postgres:
+    count: 1
+  bits:
+    count: 1
+  blobstore:
+    count: 1
+  cc_clock:
+    count: ${SIZING}
+  cc_uploader:
+    count: ${SIZING}
+  cc_worker:
+    count: ${SIZING}
+  cf_usb_group:
+    count: ${SIZING}
+  credhub_user:
+    count: ${SIZING}
+  diego_api:
+    count: ${SIZING}
+  diego_brain:
+    count: ${SIZING}
+  diego_cell:
+    count: ${DIEGO_SIZING}
+  diego_ssh:
+    count: ${SIZING}
+  doppler:
+    count: ${SIZING}
+  eirini:
+    count: ${SIZING}
+  locket:
+    count: ${SIZING}
+  log_api:
+    count: ${SIZING}
+  log_cache_scheduler:
+    count: ${SIZING}
+  loggregator_agent:
+    count: ${SIZING}
+  mysql:
+    count: ${SIZING}
+  nats:
+    count: ${SIZING}
+  nfs_broker:
+    count: 1
+  post_deployment_setup:
+    count: 1
+  router:
+    count: ${SIZING}
+  routing_api:
+    count: ${SIZING}
+  secret_generation:
+    count: 1
+
+EOF
+fi
+cat >> scf-config-values.yaml <<EOF
+kube:
+  # The IP address assigned to the kube node pointed to by the domain.
+  external_ips: [${external_ips}]
+
+  # Run kubectl get storageclasses
+  # to view your available storage classes
+  storage_class:
+    persistent: "${STORAGECLASS}"
+    shared: "${STORAGECLASS}"
+
+  # The registry the images will be fetched from.
+  # The values below should work for
+  # a default installation from the SUSE registry.
+  registry:
+    hostname: "${DOCKER_REGISTRY}"
+    username: "${DOCKER_USERNAME}"
+    password: "${DOCKER_PASSWORD}"
+  organization: "${DOCKER_ORG}"
+  auth: ${AUTH}
+
+secrets:
+  # Create a password for your CAP cluster
+  CLUSTER_ADMIN_PASSWORD: ${CLUSTER_PASSWORD}
+
+  # Create a password for your UAA client secret
+  UAA_ADMIN_CLIENT_SECRET: ${CLUSTER_PASSWORD}
+EOF
+
+fi
+
+ok "SCF config values generated"

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+
+domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+services=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["services"]')
+
+if [[ $ENABLE_EIRINI == true ]] ; then
+   # [ ! -f "helm/cf/templates/eirini-namespace.yaml" ] && kubectl create namespace eirini
+    if ! helm_ls 2>/dev/null | grep -qi metrics-server ; then
+        helm_install metrics-server stable/metrics-server\
+             --set args[0]="--kubelet-preferred-address-types=InternalIP" \
+             --set args[1]="--kubelet-insecure-tls" || true
+    fi
+
+    echo "Waiting for metrics server to come up..."
+    wait_ns default
+    sleep 10
+fi
+
+if [ "${EMBEDDED_UAA}" != "true" ] && [ "${SCF_OPERATOR}" != "true" ]; then
+
+    kubectl create namespace "uaa"
+    helm_install susecf-uaa helm/uaa --namespace uaa --values scf-config-values.yaml
+
+    wait_ns uaa
+    if [ "$services" == "lb" ]; then
+        external_dns_annotate_uaa uaa "$domain"
+    fi
+
+    SECRET=$(kubectl get pods --namespace uaa \
+    -o jsonpath='{.items[?(.metadata.name=="uaa-0")].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
+
+    CA_CERT="$(kubectl get secret "$SECRET" --namespace uaa \
+    -o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
+
+    helm_install susecf-scf helm/cf --namespace scf \
+    --values scf-config-values.yaml \
+    --set "secrets.UAA_CA_CERT=${CA_CERT}"
+
+elif [ "${SCF_OPERATOR}" == "true" ]; then
+    SCF_CHART="kubecf"
+    if [ -d "deploy/helm/scf" ]; then
+        SCF_CHART="deploy/helm/scf"
+    fi
+
+    if [ "$OPERATOR_CHART_URL" = latest ]; then
+        info "Sourcing operator from kubecf charts"
+        info "Getting latest cf-operator chart (override with OPERATOR_CHART_URL)"
+        OPERATOR_CHART_URL=$(yq r $SCF_CHART/Metadata.yaml operatorChartUrl)
+
+        # If still empty, grab latest one
+        if [ "$OPERATOR_CHART_URL" = latest ]; then
+         info "Fallback to use latest GH release of cf-operator"
+         OPERATOR_CHART_URL=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/cf-operator/releases/latest | grep "browser_download_url.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
+        fi
+    fi
+
+    info "Installing cf-operator"
+    kubectl create namespace cf-operator || true
+
+
+    echo "Installing CFO from: ${OPERATOR_CHART_URL}"
+    # Install the operator
+    helm_install cf-operator "${OPERATOR_CHART_URL}" --namespace cf-operator \
+        --set "operator-webhook-use-service-reference=true" --set "customResources.enableInstallation=true" \
+        --set "global.operator.watchNamespace=scf"
+
+    wait_ns cf-operator
+
+    info "Wait for cf-operator to be ready"
+    wait_for "kubectl get endpoints -n cf-operator cf-operator-webhook -o name"
+    wait_for "kubectl get crd quarksstatefulsets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
+    info "Test CRDs are ready"
+    #wait_for "kubectl apply -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl apply -f ../kube/cf-operator/password.yaml --namespace=scf"
+    wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
+    wait_ns scf
+    #wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
+    wait_for "kubectl delete -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
+    ok "cf-operator ready"
+
+    # KubeCF Doesn't support to setup a cluster password yet, doing it manually.
+
+    ## Versions of cf-operator prior to 4 included deployment name in front of secrets
+    ## Note: this can be dropped once we don't test anymore kubecf 1.x. in favor of the secret without the
+    ## deployment name, or either we can clearly identify the operator version without hackish ways.
+    kubectl create secret generic -n scf susecf-scf.var-cf-admin-password --from-literal=password="${CLUSTER_PASSWORD}"
+
+    ## CF-Operator >= 4 don't have deployment name in front of secrets name anymore
+    kubectl create secret generic -n scf var-cf-admin-password --from-literal=password="${CLUSTER_PASSWORD}"
+
+    helm_install susecf-scf ${SCF_CHART} \
+    --namespace scf \
+    --values scf-config-values.yaml
+
+    sleep 540
+else
+
+    kubectl create namespace "scf"
+    helm_install susecf-scf helm/cf --namespace scf \
+    --values scf-config-values.yaml \
+    --set enable.uaa=true
+
+    wait_ns uaa
+    if [ "$services" == "lb" ]; then
+        external_dns_annotate_uaa uaa "$domain"
+    fi
+fi
+
+wait_ns scf
+if [ "$services" == "lb" ]; then
+    external_dns_annotate_scf scf "$domain"
+fi
+
+ok "SCF deployed successfully"

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -87,4 +87,4 @@ if [ "$services" == "lb" ]; then
     external_dns_annotate_kubecf scf "$domain"
 fi
 
-ok "SCF deployed successfully"
+ok "KubeCF deployed successfully"

--- a/modules/kubecf/klog.sh
+++ b/modules/kubecf/klog.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+curl -Lo klog.sh "$SCF_REPO"/raw/"$SCF_BRANCH"/container-host-files/opt/scf/bin/klog.sh
+chmod +x klog.sh
+mv klog.sh bin/
+
+klog.sh

--- a/modules/kubecf/login.sh
+++ b/modules/kubecf/login.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+
+if [ -n "$EKCP_PROXY" ]; then
+    export https_proxy=socks5://127.0.0.1:${KUBEPROXY_PORT}
+fi
+
+domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+
+mkdir -p "$CF_HOME"
+
+# It might take some time for external DNS records to update so make a few attempts to login before bailing out.
+n=0
+until [ $n -ge 20 ]
+do
+   cf login --skip-ssl-validation -a https://api."$domain" -u admin -p "$CLUSTER_PASSWORD" -o system && break
+   n=$[$n+1]
+   sleep 60
+done
+
+cf create-space tmp
+cf target -s tmp
+
+ok "Logged in to SCF"

--- a/modules/kubecf/minibroker.sh
+++ b/modules/kubecf/minibroker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+# delete previous deployments
+if cf service-brokers 2>/dev/null | grep -qi minibroker ; then
+    cf delete-service-broker minibroker -f
+fi
+if helm_ls 2>/dev/null | grep -qi minibroker ; then
+    helm_delete minibroker
+fi
+if kubectl get namespaces 2>/dev/null | grep -qi minibroker ; then
+    kubectl delete --ignore-not-found namespace minibroker
+fi
+
+ORG=$(cf target | grep "org:" | tr -s " " | cut -d " " -f 2)
+
+helm_install minibroker suse/minibroker --namespace minibroker --set "defaultNamespace=minibroker"
+
+wait_ns minibroker
+
+# username and password are dummies
+cf create-service-broker minibroker username password http://minibroker-minibroker.minibroker.svc.cluster.local
+
+cf service-brokers
+
+info "Listing services and plans that the minibroker service has access to:"
+cf service-access -b minibroker
+
+info "Enabling postgresql service"
+cf enable-service-access postgresql -b minibroker -p 11-6-0
+echo > postgresql.json '[{ "protocol": "tcp", "destination": "10.0.0.0/8", "ports": "5432", "description": "Allow PostgreSQL traffic" }]'
+cf create-security-group postgresql_networking postgresql.json
+cf bind-security-group postgresql_networking $ORG
+
+info "Enabling redis service"
+cf enable-service-access redis -b minibroker -p 5-0-7
+echo > redis.json '[{ "protocol": "tcp", "destination": "10.0.0.0/8", "ports": "6379", "description": "Allow Redis traffic" }]'
+cf create-security-group redis_networking redis.json
+cf bind-security-group redis_networking $ORG
+
+info "Create postgresql service"
+cf create-service postgresql 11-6-0 postgresql-service
+wait_ns minibroker
+
+info "Create redis service"
+cf create-service redis 5-0-7 redis-service
+wait_ns minibroker
+
+ok "Deployed minibroker and services successfully"

--- a/modules/kubecf/precheck.sh
+++ b/modules/kubecf/precheck.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+
+curl -Lo kube-ready-state-check.sh "$SCF_REPO"/raw/"$SCF_BRANCH"/bin/dev/kube-ready-state-check.sh
+chmod +x kube-ready-state-check.sh
+mv kube-ready-state-check.sh bin/
+
+kube-ready-state-check.sh kube

--- a/modules/kubecf/purge.sh
+++ b/modules/kubecf/purge.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+. ../../include/common.sh
+. .envrc
+
+# Purging it's a best-effort action
+set +e
+
+info "Purging all apps, buildpacks and services from the CF instance"
+
+# Delete leftover apps
+for app in $(cf apps | gawk '{print $1}'); do cf delete -f $app; done
+
+# Delete all buildpacks (in case there are leftovers)
+for buildpack in $(cf buildpacks | tail -n +4 | gawk '{print $1}'); do cf delete-buildpack -f $buildpack; done
+
+if [ -n "$CF_STACK" ]; then
+    for buildpack in $(cf buildpacks | tail -n +4 | gawk '{print $1}'); do cf delete-buildpack -f $buildpack -s "$CF_STACK"; done
+fi
+
+# Delete all services
+for service in $(cf services | tail -n +4 | gawk '{print $1}'); do cf delete-service -f $service; done
+
+ok "Purge completed"

--- a/modules/kubecf/stemcell_build.sh
+++ b/modules/kubecf/stemcell_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. ../../include/common.sh
+. .envrc
+
+
+[ ! -d "bosh-linux-stemcell-builder" ] && \
+    git clone https://github.com/SUSE/bosh-linux-stemcell-builder.git
+
+pushd bosh-linux-stemcell-builder || exit
+    git checkout devel
+    make all
+popd || exit

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -17,4 +17,4 @@ sleep 10
 
 wait_ns scf
 
-ok "SCF deployment upgraded successfully"
+ok "KubeCF deployment upgraded successfully"

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -10,34 +10,10 @@ if [ -n "$SCF_CHART" ]; then
     kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'
 fi
 
-if [ "${SCF_OPERATOR}" == "true" ]; then
-
-    helm_upgrade susecf-scf kubecf/ \
-                 --namespace scf \
-                 --values scf-config-values.yaml
-    sleep 10
-
-else
-
-    SECRET=$(kubectl get pods --namespace uaa \
-    -o jsonpath='{.items[?(.metadata.name=="uaa-0")].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
-
-    CA_CERT="$(kubectl get secret "$SECRET" --namespace uaa \
-    -o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
-
-    if [ "$UAA_UPGRADE" == true ]; then
-
-        helm_upgrade susecf-uaa helm/uaa/ --values scf-config-values.yaml \
-        --set "secrets.UAA_CA_CERT=${CA_CERT}"
-
-        wait_ns uaa
-
-    fi
-
-
-    helm_upgrade susecf-scf helm/cf/ --values scf-config-values.yaml \
-    --set "secrets.UAA_CA_CERT=${CA_CERT}"
-fi
+helm_upgrade susecf-scf kubecf/ \
+             --namespace scf \
+             --values scf-config-values.yaml
+sleep 10
 
 wait_ns scf
 

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+
+if [ -n "$SCF_CHART" ]; then
+# save SCF_CHART on cap-values configmap
+    kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'
+fi
+
+if [ "${SCF_OPERATOR}" == "true" ]; then
+
+    helm_upgrade susecf-scf kubecf/ \
+                 --namespace scf \
+                 --values scf-config-values.yaml
+    sleep 10
+
+else
+
+    SECRET=$(kubectl get pods --namespace uaa \
+    -o jsonpath='{.items[?(.metadata.name=="uaa-0")].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
+
+    CA_CERT="$(kubectl get secret "$SECRET" --namespace uaa \
+    -o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
+
+    if [ "$UAA_UPGRADE" == true ]; then
+
+        helm_upgrade susecf-uaa helm/uaa/ --values scf-config-values.yaml \
+        --set "secrets.UAA_CA_CERT=${CA_CERT}"
+
+        wait_ns uaa
+
+    fi
+
+
+    helm_upgrade susecf-scf helm/cf/ --values scf-config-values.yaml \
+    --set "secrets.UAA_CA_CERT=${CA_CERT}"
+fi
+
+wait_ns scf
+
+ok "SCF deployment upgraded successfully"

--- a/modules/scf/build.sh
+++ b/modules/scf/build.sh
@@ -16,21 +16,14 @@ else
 fi
 
 GIT_HEAD=$(git log --pretty=format:'%h' -n 1)
-if [ "$SCF_OPERATOR" == "true" ]; then
-    rm -rfv bazel-bin/deploy/helm/kubecf/* || true
-    bazel build //deploy/helm/kubecf
-    tar -xvf bazel-bin/deploy/helm/kubecf/kubecf.tgz -C "$BUILD_DIR"
-    SCF_CHART=kubecf-"$GIT_HEAD"
-else
-    sed -i 's|exit 1||' make/kube-dist || true
-    sed -i 's|exit 1||' make/bundle-dist || true
-    docker exec "$DOCKER_OPTS" \
-    -ti "$CLUSTER_NAME"-control-plane \
-    /bin/bash -exc ' apt-get update && apt-get install -y ruby git wget make; cd /code/scf && chmod -R 777 src && source .envrc && ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
-    cp -rfv output/*.zip ../
-    unzip -o ./*.zip
-    SCF_CHART=scf-"$GIT_HEAD"
-fi
+sed -i 's|exit 1||' make/kube-dist || true
+sed -i 's|exit 1||' make/bundle-dist || true
+docker exec "$DOCKER_OPTS" \
+-ti "$CLUSTER_NAME"-control-plane \
+/bin/bash -exc ' apt-get update && apt-get install -y ruby git wget make; cd /code/scf && chmod -R 777 src && source .envrc && ./bin/dev/install_tools.sh && make vagrant-prep bundle-dist'
+cp -rfv output/*.zip ../
+unzip -o ./*.zip
+SCF_CHART=scf-"$GIT_HEAD"
 popd || exit
 
 # save SCF_CHART on cap-values configmap

--- a/modules/scf/chart.sh
+++ b/modules/scf/chart.sh
@@ -8,11 +8,7 @@ rm -rf helm chart scf_chart_url suse kubecf
 
 if [ -z "$SCF_CHART" ] && [ -z "$SCF_HELM_VERSION" ]; then
     warn "No chart url given - using latest public release from GH"
-    if  [ "${SCF_OPERATOR}" != "true" ]; then
-        SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
-    else
-        SCF_CHART=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/kubecf/releases/latest | grep "browser_download_url.*bundle.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
-    fi
+    SCF_CHART=$(curl -s https://api.github.com/repos/SUSE/scf/releases/latest | grep "browser_download_url.*zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
 fi
 
 if [ -n "$SCF_HELM_VERSION" ]; then
@@ -67,14 +63,6 @@ if echo "$SCF_CHART" | grep -q "tgz"; then
     tar -xvf chart -C ./
 else
     unzip -o chart
-fi
-
-if  [ "${SCF_OPERATOR}" == "true" ]; then
-    if echo "$SCF_CHART" | grep -q "bundle"; then
-        tar xvzf cf-operator*.tgz
-        tar xvzf kubecf*.tgz
-    fi
-    cp -rfv kubecf*/* ./
 fi
 
 # save SCF_CHART on cap-values configmap

--- a/modules/scf/clean.sh
+++ b/modules/scf/clean.sh
@@ -45,11 +45,6 @@ fi
 
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
 
-if [ "${SCF_OPERATOR}" == "true" ]; then
-    rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
-       imagelist.txt requirements.lock  requirements.yaml
-fi
-
 # delete SCF_CHART on cap-values configmap
 if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.chart // empty')" ]]; then
     kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/chart"}]'

--- a/modules/scf/defaults.sh
+++ b/modules/scf/defaults.sh
@@ -51,3 +51,6 @@ SCF_LOCAL="${SCF_LOCAL:-}"
 
 SCF_OPERATOR="${SCF_OPERATOR:-false}"
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
+
+SCF_REPO="${SCF_REPO:-https://github.com/SUSE/scf}"
+SCF_BRANCH="${SCF_BRANCH:-develop}"

--- a/modules/scf/defaults.sh
+++ b/modules/scf/defaults.sh
@@ -49,7 +49,6 @@ SCF_LOCAL="${SCF_LOCAL:-}"
 
 # relevant to several:
 
-SCF_OPERATOR="${SCF_OPERATOR:-false}"
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 
 SCF_REPO="${SCF_REPO:-https://github.com/SUSE/scf}"

--- a/modules/scf/gen_config.sh
+++ b/modules/scf/gen_config.sh
@@ -6,20 +6,17 @@
 
 
 info "Generating SCF config values"
-if [ "$SCF_OPERATOR" != true ]; then
-    if [ "${DEFAULT_STACK}" = "from_chart" ]; then
-        if [[ "$HELM_VERSION" == v3* ]];
-        then
-          DEFAULT_STACK=$(helm show values helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
-        else
-          DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
-        fi
-        export DEFAULT_STACK
+if [ "${DEFAULT_STACK}" = "from_chart" ]; then
+    if [[ "$HELM_VERSION" == v3* ]];
+    then
+      DEFAULT_STACK=$(helm show values helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+    else
+      DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
     fi
+    export DEFAULT_STACK
 fi
 
 kubectl patch -n kube-system configmap cap-values -p $'data:\n services: "'$SCF_SERVICES'"'
-services="$SCF_SERVICES"
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
 array_external_ips=()
@@ -53,101 +50,7 @@ sizing:
     capabilities: ["SYS_RESOURCE"]
 END_HEREDOC
 )
-
 fi
-
-if [ "${SCF_OPERATOR}" == "true" ]; then
-
-
-if [ "$services" == ingress ]; then
-INGRESS_BLOCK="ingress:
-    enabled: true
-    tls:
-      crt: ~
-      key: ~
-    annotations: {}
-    labels: {}
-"
-else
-INGRESS_BLOCK=''
-fi
-
-cat > scf-config-values.yaml <<EOF
-system_domain: $domain
-
-features:
-  eirini:
-    enabled: ${ENABLE_EIRINI}
-  autoscaler:
-    enabled: ${AUTOSCALER}
-  ${INGRESS_BLOCK}
-
-kube:
-  service_cluster_ip_range: 0.0.0.0/0
-  pod_cluster_ip_range: 0.0.0.0/0
-
-  registry:
-    hostname: "${DOCKER_REGISTRY}"
-    username: "${DOCKER_USERNAME}"
-    password: "${DOCKER_PASSWORD}"
-  organization: "${DOCKER_ORG}"
-
-high_availability: ${HA}
-
-testing:
-  brain_tests:
-    enabled: true
-  cf_acceptance_tests:
-    enabled: true
-  smoke_tests:
-    enabled: true
-  sync_integration_tests:
-    enabled: true
-properties:
-  acceptance-tests:
-    acceptance-tests:
-      acceptance_tests:
-        timeout_scale: ${CATS_TIMEOUT_SCALE}
-        ginkgo:
-          slow_spec_threshold: 300
-          nodes: ${CATS_NODES}
-          flake_attempts: ${CATS_FLAKE_ATTEMPTS}
-  brain-tests:
-    acceptance-tests-brain:
-      acceptance_tests_brain:
-        verbose: "${BRAIN_VERBOSE}"
-        in_order: "${BRAIN_INORDER}"
-        include: "${BRAIN_INCLUDE}"
-        exclude: "${BRAIN_EXCLUDE}"
-EOF
-
-if [ "${services}" == "lb" ]; then
-    cat >> scf-config-values.yaml <<EOF
-#  External endpoints are created for the instance groups only if
-#  features.ingress.enabled is false.
-services:
-  router:
-    type: LoadBalancer
-    externalIPs: [${external_ips}]
-  ssh-proxy:
-    type: LoadBalancer
-    externalIPs: [${external_ips}]
-  tcp-router:
-    type: LoadBalancer
-    externalIPs: [${external_ips}]
-    port_range:
-      start: 20000
-      end: 20008
-EOF
-fi
-
-# CONFIG_OVERRIDE last, to actually override
-cat >> scf-config-values.yaml <<EOF
-${CONFIG_OVERRIDE}
-EOF
-
-else
-# SCF_OPERATOR != true
 
 cat > scf-config-values.yaml <<EOF
 env:
@@ -280,7 +183,5 @@ secrets:
   # Create a password for your UAA client secret
   UAA_ADMIN_CLIENT_SECRET: ${CLUSTER_PASSWORD}
 EOF
-
-fi
 
 ok "SCF config values generated"

--- a/modules/scf/install.sh
+++ b/modules/scf/install.sh
@@ -21,7 +21,7 @@ if [[ $ENABLE_EIRINI == true ]] ; then
     sleep 10
 fi
 
-if [ "${EMBEDDED_UAA}" != "true" ] && [ "${SCF_OPERATOR}" != "true" ]; then
+if [ "${EMBEDDED_UAA}" != "true" ]; then
 
     kubectl create namespace "uaa"
     helm_install susecf-uaa helm/uaa --namespace uaa --values scf-config-values.yaml
@@ -40,70 +40,7 @@ if [ "${EMBEDDED_UAA}" != "true" ] && [ "${SCF_OPERATOR}" != "true" ]; then
     helm_install susecf-scf helm/cf --namespace scf \
     --values scf-config-values.yaml \
     --set "secrets.UAA_CA_CERT=${CA_CERT}"
-
-elif [ "${SCF_OPERATOR}" == "true" ]; then
-    SCF_CHART="kubecf"
-    if [ -d "deploy/helm/scf" ]; then
-        SCF_CHART="deploy/helm/scf"
-    fi
-
-    if [ "$OPERATOR_CHART_URL" = latest ]; then
-        info "Sourcing operator from kubecf charts"
-        info "Getting latest cf-operator chart (override with OPERATOR_CHART_URL)"
-        OPERATOR_CHART_URL=$(yq r $SCF_CHART/Metadata.yaml operatorChartUrl)
-
-        # If still empty, grab latest one
-        if [ "$OPERATOR_CHART_URL" = latest ]; then
-         info "Fallback to use latest GH release of cf-operator"
-         OPERATOR_CHART_URL=$(curl -s https://api.github.com/repos/cloudfoundry-incubator/cf-operator/releases/latest | grep "browser_download_url.*tgz" | cut -d : -f 2,3 | tr -d \" | tr -d " ")
-        fi
-    fi
-
-    info "Installing cf-operator"
-    kubectl create namespace cf-operator || true
-
-
-    echo "Installing CFO from: ${OPERATOR_CHART_URL}"
-    # Install the operator
-    helm_install cf-operator "${OPERATOR_CHART_URL}" --namespace cf-operator \
-        --set "operator-webhook-use-service-reference=true" --set "customResources.enableInstallation=true" \
-        --set "global.operator.watchNamespace=scf"
-
-    wait_ns cf-operator
-
-    info "Wait for cf-operator to be ready"
-    wait_for "kubectl get endpoints -n cf-operator cf-operator-webhook -o name"
-    wait_for "kubectl get crd quarksstatefulsets.quarks.cloudfoundry.org -o name"
-    wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
-    wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
-    wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
-    info "Test CRDs are ready"
-    #wait_for "kubectl apply -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
-    wait_for "kubectl apply -f ../kube/cf-operator/password.yaml --namespace=scf"
-    wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
-    wait_ns scf
-    #wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
-    wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
-    wait_for "kubectl delete -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
-    ok "cf-operator ready"
-
-    # KubeCF Doesn't support to setup a cluster password yet, doing it manually.
-
-    ## Versions of cf-operator prior to 4 included deployment name in front of secrets
-    ## Note: this can be dropped once we don't test anymore kubecf 1.x. in favor of the secret without the
-    ## deployment name, or either we can clearly identify the operator version without hackish ways.
-    kubectl create secret generic -n scf susecf-scf.var-cf-admin-password --from-literal=password="${CLUSTER_PASSWORD}"
-
-    ## CF-Operator >= 4 don't have deployment name in front of secrets name anymore
-    kubectl create secret generic -n scf var-cf-admin-password --from-literal=password="${CLUSTER_PASSWORD}"
-
-    helm_install susecf-scf ${SCF_CHART} \
-    --namespace scf \
-    --values scf-config-values.yaml
-
-    sleep 540
 else
-
     kubectl create namespace "scf"
     helm_install susecf-scf helm/cf --namespace scf \
     --values scf-config-values.yaml \

--- a/modules/scf/upgrade.sh
+++ b/modules/scf/upgrade.sh
@@ -10,34 +10,20 @@ if [ -n "$SCF_CHART" ]; then
     kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'
 fi
 
-if [ "${SCF_OPERATOR}" == "true" ]; then
+SECRET=$(kubectl get pods --namespace uaa \
+-o jsonpath='{.items[?(.metadata.name=="uaa-0")].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
 
-    helm_upgrade susecf-scf kubecf/ \
-                 --namespace scf \
-                 --values scf-config-values.yaml
-    sleep 10
+CA_CERT="$(kubectl get secret "$SECRET" --namespace uaa \
+-o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
 
-else
-
-    SECRET=$(kubectl get pods --namespace uaa \
-    -o jsonpath='{.items[?(.metadata.name=="uaa-0")].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
-
-    CA_CERT="$(kubectl get secret "$SECRET" --namespace uaa \
-    -o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
-
-    if [ "$UAA_UPGRADE" == true ]; then
-
-        helm_upgrade susecf-uaa helm/uaa/ --values scf-config-values.yaml \
-        --set "secrets.UAA_CA_CERT=${CA_CERT}"
-
-        wait_ns uaa
-
-    fi
-
-
-    helm_upgrade susecf-scf helm/cf/ --values scf-config-values.yaml \
+if [ "$UAA_UPGRADE" == true ]; then
+    helm_upgrade susecf-uaa helm/uaa/ --values scf-config-values.yaml \
     --set "secrets.UAA_CA_CERT=${CA_CERT}"
+    wait_ns uaa
 fi
+
+helm_upgrade susecf-scf helm/cf/ --values scf-config-values.yaml \
+--set "secrets.UAA_CA_CERT=${CA_CERT}"
 
 wait_ns scf
 


### PR DESCRIPTION
This PR separates and simplifies kubecf and scf code without breaking the UI.

It:
- Adds a new `module/kubecf/*`, and its targets `make kubecf*`.
- Provides compatibility for users & ci by pointing `SCF_OPERATOR make scf*` to `make kubecf`.
- Maintains the rest of `SCF_*` variables for both modules, to not break compatibility.
- Refactors kubecf code into `modules/kubecf/*`, and scf code into `modules/scf/*`.
- Removes the need of SCF_OPERATOR on both modules.
- Adds sane defaults for both kubecf and scf modules.

It maybe it's useful to review this PR by commits instead of files, given the copied files, etc.