### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,12 @@ RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.
 RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
   chmod +x aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
 
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz \
-&& mkdir -p /usr/local/gcloud \
-&& tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-&& /usr/local/gcloud/google-cloud-sdk/install.sh --quiet
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-292.0.0-linux-x86_64.tar.gz \
+         > /tmp/google-cloud-sdk.tar.gz \
+  && mkdir -p /usr/local/gcloud \
+  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz && rm -rf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh --override-components gcloud --quiet
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl && \
   mv kubectl-aws /usr/local/bin/ && chmod +x /usr/local/bin/kubectl-aws
@@ -45,8 +47,6 @@ RUN zypper in --no-recommends -y gcc libffi-devel python3-devel libopenssl-devel
 RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
   printf "\n\n\n\n" | python3 ./install.py && \
   rm ./install.py
-
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 RUN zypper rm -y glibc-locale && zypper clean --all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && 
 
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-RUN zypper clean --all
+RUN zypper rm -y glibc-locale && zypper clean --all
 
 ADD . /catapult
 WORKDIR /catapult

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -o kubectl-aws https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/201
 
 RUN zypper in --no-recommends -y gcc libffi-devel python3-devel libopenssl-devel
 RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && \
-  printf "\n\n\n\n" | python3 ./install.py && \
+  printf "/usr/local/lib/azure-cli\n/usr/local/bin\n\n\n" | python3 ./install.py && \
   rm ./install.py
 
 RUN zypper rm -y glibc-locale && zypper clean --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN zypper ar --priority 100 https://download.opensuse.org/repositories/Cloud:To
   zypper --gpg-auto-import-keys -n in --no-recommends -y Cloud_Tools:kubernetes-client
 
 RUN helm_version=v3.1.1 \
-&& wget https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz -O - | tar xz -C /usr/bin --strip-components=1 linux-amd64/helm
+  && wget https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz -O - | tar xz -C /usr/bin --strip-components=1 linux-amd64/helm
 
 # k8s backends dependencies:
 RUN zypper in --no-recommends -y terraform


### PR DESCRIPTION
Reduced from 3.12GB to 2.88GB.
Achieved by:
- Reducing the default components for gcloud
- Removing unneeded locales

Successfully tested by spawning the image, and trying to login and list account settings with `gcloud` and `az`.