### PR TITLE
Simplify kubecf clean

### DIFF
--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -7,6 +7,9 @@
 # if no kubeconfig, no cf. Exit
 [ -f "$KUBECONFIG" ] || exit 0
 
+# clean pvcs
+kubectl get -n scf pvc -o name \
+    | xargs --no-run-if-empty kubectl delete -n scf
 
 if helm_ls 2>/dev/null | grep -qi susecf-scf ; then
     helm_delete susecf-scf --namespace scf

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -26,13 +26,11 @@ if kubectl get namespaces 2>/dev/null | grep -qi cf-operator ; then
     kubectl delete --ignore-not-found namespace cf-operator
 fi
 
-if [[ "$ENABLE_EIRINI" == true ]] ; then
-    if kubectl get namespaces 2>/dev/null | grep -qi eirini ; then
-        kubectl delete --ignore-not-found namespace eirini
-    fi
-    if helm_ls 2>/dev/null | grep -qi metrics-server ; then
-        helm_delete metrics-server
-    fi
+if kubectl get namespaces 2>/dev/null | grep -qi eirini ; then
+    kubectl delete --ignore-not-found namespace eirini
+fi
+if helm_ls 2>/dev/null | grep -qi metrics-server ; then
+    helm_delete metrics-server
 fi
 
 rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -33,7 +33,7 @@ if helm_ls 2>/dev/null | grep -qi metrics-server ; then
     helm_delete metrics-server
 fi
 
-rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf kube-ready-state-check.sh
+rm -rf scf-config-values.yaml chart helm kube "$CF_HOME"/.cf
 
 rm -rf cf-operator* kubecf* assets templates Chart.yaml values.yaml Metadata.yaml \
    imagelist.txt requirements.lock  requirements.yaml

--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -7,14 +7,6 @@
 # if no kubeconfig, no cf. Exit
 [ -f "$KUBECONFIG" ] || exit 0
 
-if [ "$EMBEDDED_UAA" != "true" ]; then
-    if helm_ls 2>/dev/null | grep -qi susecf-uaa ; then
-        helm_delete susecf-uaa
-    fi
-    if kubectl get namespaces 2>/dev/null | grep -qi uaa ; then
-        kubectl delete --ignore-not-found namespace uaa
-    fi
-fi
 
 if helm_ls 2>/dev/null | grep -qi susecf-scf ; then
     helm_delete susecf-scf --namespace scf

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -19,8 +19,6 @@ DIEGO_SIZING="${DIEGO_SIZING:-$SIZING}"
 STORAGECLASS="${STORAGECLASS:-persistent}"
 AUTOSCALER="${AUTOSCALER:-false}"
 
-EMBEDDED_UAA="${EMBEDDED_UAA:-false}"
-
 HA="${HA:-false}"
 if [ "$HA" = "true" ]; then
     SIZING="${SIZING:-2}"

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -74,14 +74,18 @@ testBackendImported() {
     rm -rf buildtest
     BACKEND=imported make buildir
     assertTrue 'create buildir' "[ -d 'buildtest' ]"
+
     ENVRC="$(cat "$PWD"/buildtest/.envrc)"
     assertContains 'contains BACKEND' "$ENVRC" 'BACKEND=imported'
+
     echo "foo" > buildtest/kubeconfig_orig
     KUBECFG=$(pwd)/buildtest/kubeconfig_orig \
               BACKEND=imported \
               make kubeconfig
     assertTrue 'imported kubeconfig' 'diff "$PWD"/buildtest/kubeconfig "$PWD"/buildtest/kubeconfig_orig'
     assertFalse "BACKEND=imported make check must fail" 'BACKEND=imported make private backends/imported check'
+    rm buildtest/kubeconfig # cleanup the broken kubeconfig used for testing
+
     BACKEND=imported make clean
     assertTrue 'clean buildir' "[ ! -d 'buildtest' ]"
 }


### PR DESCRIPTION
Delete eirini things regardless of env vars.
Delete pvcs if existing.
Remove EMBEDDED_UAA logic for kubecf, as it isn't needed anymore.
