### PR TITLE
Add corenumber option for CATS_NODES

### DIFF
--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -38,7 +38,7 @@ BRAIN_INORDER="${BRAIN_INORDER:-false}"
 BRAIN_INCLUDE="${BRAIN_INCLUDE:-}"
 BRAIN_EXCLUDE="${BRAIN_EXCLUDE:-}"
 
-CATS_NODES="${CATS_NODES:-1}"
+CATS_NODES="${CATS_NODES:-corenumber}" # if "corenumber": set it to number of cores. Else, a numeric value.
 CATS_FLAKE_ATTEMPTS="${CATS_FLAKE_ATTEMPTS:-5}"
 CATS_TIMEOUT_SCALE="${CATS_TIMEOUT_SCALE:-3.0}"
 

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -32,10 +32,10 @@ else
 INGRESS_BLOCK=''
 fi
 
-last_worker=$(kubectl get nodes | tail -1 | cut -f 1 -d ' ')
-num_cores=$(kubectl describe node "$last_worker" | \
-          grep Allocatable -A 2 | grep cpu | tr -s ' ' | cut -f 3 -d ' ')
 if [ "$CATS_NODES" == corenumber ]; then
+    last_worker=$(kubectl get nodes | tail -1 | cut -f 1 -d ' ')
+    num_cores=$(kubectl describe node "$last_worker" | \
+                    grep Allocatable -A 2 | grep cpu | tr -s ' ' | cut -f 3 -d ' ')
     CATS_NODES="$num_cores"
 fi
 

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -32,6 +32,13 @@ else
 INGRESS_BLOCK=''
 fi
 
+last_worker=$(kubectl get nodes | tail -1 | cut -f 1 -d ' ')
+num_cores=$(kubectl describe node "$last_worker" | \
+          grep Allocatable -A 2 | grep cpu | tr -s ' ' | cut -f 3 -d ' ')
+if [ "$CATS_NODES" == corenumber ]; then
+    CATS_NODES="$num_cores"
+fi
+
 cat > scf-config-values.yaml <<EOF
 system_domain: $domain
 


### PR DESCRIPTION
if CATS_NODES set to "corenumber", spawn as many ginkgo nodes as cores the
k8s workers have.