### PR TITLE
Disable eirini by default

### DIFF
--- a/include/defaults_global.sh
+++ b/include/defaults_global.sh
@@ -8,7 +8,7 @@ export DOCKER_ORG="${DOCKER_ORG:-cap}"
 
 export DEFAULT_STACK="${DEFAULT_STACK:-from_chart}" # from_chart, sle15, sle12, cfslinuxfs2, cfslinuxfs3
 export MAGICDNS="${MAGICDNS:-omg.howdoi.website}"
-export ENABLE_EIRINI="${ENABLE_EIRINI:-true}"
+export ENABLE_EIRINI="${ENABLE_EIRINI:-false}"
 export EKCP_PROXY="${EKCP_PROXY:-}"
 export KUBEPROXY_PORT="${KUBEPROXY_PORT:-2224}"
 export QUIET_OUTPUT="${QUIET_OUTPUT:-false}"


### PR DESCRIPTION
Set ENABLE_EIRINI=false by default. This helps local deployments, and we can revisit this later once eirini reliably passes cats.