### PR TITLE
fix: kubecf: quarks-operator 5.x compatibility

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -284,6 +284,12 @@ function helm_ls {
     fi
 }
 
+# Given a chart path in $1, find its app version
+function helm_chart_app_version {
+    # helm 3 aliases "inspect" to "show", so the syntax is the same for 2 & 3.
+    helm inspect chart "${1}" | yq read - appVersion
+}
+
 function wait_for {
     info "Waiting for $1"
     timeout=300


### PR DESCRIPTION
Make the cf-operator install command support both 4.x and 5.x (by supplying the required namespace both ways).

This was used to push operator 5.0.0 to GKE; seems to work.