### PR TITLE
Remove bazel from Catapult

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed:latest
 # Catapult dependencies:
-RUN zypper ref && zypper in --no-recommends -y git zip wget docker ruby gzip make jq curl which unzip bazel1.2 direnv
+RUN zypper ref && zypper in --no-recommends -y git zip wget docker ruby gzip make jq curl which unzip direnv
 RUN echo 'eval $(direnv hook bash)' >> ~/.bashrc
 
 RUN wget "https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64" -O /usr/local/bin/yq && \

--- a/modules/common/defaults.sh
+++ b/modules/common/defaults.sh
@@ -5,5 +5,4 @@
 
 # Default versions in case the are undefined in the backend:
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.17.0}"
-BAZEL_VERSION="${BAZEL_VERSION:-1.1.0}"
 export HELM_VERSION="${HELM_VERSION:-v3.1.1}"

--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -57,12 +57,6 @@ fi
 if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
     ok "Skipping downloading catapult dependencies, using host binaries"
 else
-    bazelpath=bin/bazel
-    if [ ! -e "$bazelpath" ]; then
-        wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64" -O $bazelpath
-        chmod +x $bazelpath
-    fi
-
     yamlpatchpath=bin/yaml-patch
     if [ ! -e "$yamlpatchpath" ]; then
         wget "https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_${YAMLPATCH_OS_TYPE}" -O $yamlpatchpath

--- a/modules/kubecf/build.sh
+++ b/modules/kubecf/build.sh
@@ -16,9 +16,8 @@ else
 fi
 
 GIT_HEAD=$(git log --pretty=format:'%h' -n 1)
-rm -rfv bazel-bin/deploy/helm/kubecf/* || true
-bazel build //deploy/helm/kubecf
-tar -xvf bazel-bin/deploy/helm/kubecf/kubecf.tgz -C "$BUILD_DIR"
+./scripts/kubecf-build.sh
+tar -xvf "$(ls -t1 output/kubecf-*.tgz | head -n 1 )" -C "$BUILD_DIR"
 SCF_CHART=kubecf-"$GIT_HEAD"
 popd || exit
 

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -180,7 +180,6 @@ testCommonDeps() {
   make buildir
   DOWNLOAD_BINS=false DOWNLOAD_CATAPULT_DEPS=false make private modules/common
 
-  assertFalse 'bazel not downloaded' "[ -e 'buildtest/bin/bazel' ]"
   assertFalse 'yaml-patch not downloaded' "[ -e 'buildtest/bin/yaml-patch' ]"
   assertFalse 'yq not downloaded' "[ -e 'buildtest/bin/yq' ]"
 
@@ -190,7 +189,6 @@ testCommonDeps() {
   make buildir
   DOWNLOAD_BINS=false DOWNLOAD_CATAPULT_DEPS=true make private modules/common
 
-  assertTrue 'bazel downloaded' "[ -e 'buildtest/bin/bazel' ]"
   assertTrue 'yaml-patch downloaded' "[ -e 'buildtest/bin/yaml-patch' ]"
   assertTrue 'yq downloaded' "[ -e 'buildtest/bin/yq' ]"
 


### PR DESCRIPTION
- Remove bazel binary from dependencies: don't download it on common/deps.sh, nor unit test it, nor add it into the
Docker image.
- Use bash scripts instead of bazel in kubecf/build.sh, for `make kubecf-build`

Note that `make kubecf-build` is not used in CI, so no functionality is lost merging this.

Tested by calling `SCF_LOCAL=~/suse/kubecf make kubecf-build` to build and deploy kubecf.