### PR TITLE
feat: backend: custom owner

### DIFF
--- a/backend/aks/defaults.sh
+++ b/backend/aks/defaults.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
+# Common options
+##################
+
+OWNER="${OWNER:-$(whoami)}"
+
 # AKS options
 ##################
 
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.18.2}"
 
-AZURE_CLUSTER_NAME="${AZURE_CLUSTER_NAME:-$(whoami)-cap}"
+AZURE_CLUSTER_NAME="${AZURE_CLUSTER_NAME:-${OWNER}-cap}"
 AZURE_NODE_COUNT="${AZURE_NODE_COUNT:-3}"
 AZURE_LOCATION="${AZURE_LOCATION:-westus}"
 AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-}"

--- a/backend/aks/deploy.sh
+++ b/backend/aks/deploy.sh
@@ -49,7 +49,7 @@ location          = "${AZURE_LOCATION}"
 agent_admin       = "cap-admin"
 cluster_labels    = {
     "catapult-cluster" = "${AZURE_CLUSTER_NAME}",
-    "owner"            = "$(whoami)"
+    "owner"            = "${OWNER}"
 }
 k8s_version       = "${KUBECTL_VERSION#v}"
 azure_dns_json    = "${AZURE_DNS_JSON}"

--- a/backend/caasp4os/defaults.sh
+++ b/backend/caasp4os/defaults.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Common options
+##################
+
+OWNER="${OWNER:-$(whoami)}"
+
 # Caasp4os options
 ##################
 

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -15,7 +15,7 @@
 export MAGICDNS=omg.howdoi.website
 
 # Create STACK var for terraform, and for the node names in lib/skuba.sh:
-STACK=${STACK:-"$(whoami)-caasp4-${CAASP_VER::3}-$CLUSTER_NAME"}
+STACK=${STACK:-"${OWNER}-caasp4-${CAASP_VER::3}-${CLUSTER_NAME}"}
 # shellcheck disable=SC1090
 . "$ROOT_DIR"/backend/caasp4os/lib/skuba.sh
 

--- a/backend/eks/defaults.sh
+++ b/backend/eks/defaults.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 
+# Common options
+##################
+
+OWNER="${OWNER:-$(whoami)}"
+
 # EKS options
 #############
 
-EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-$(whoami)-cap}"
+EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-${OWNER}-cap}"
 EKS_LOCATION="${EKS_LOCATION:-us-west-2}"
-EKS_KEYPAIR="${EKS_KEYPAIR:-$(whoami)-terraform}"
+EKS_KEYPAIR="${EKS_KEYPAIR:-${OWNER}-terraform}"
 EKS_VERS="${EKS_VERS:-1.14}"
-EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-\{key = \"$(whoami)-eks-cluster\"\}}
+EKS_CLUSTER_LABEL=${EKS_CLUSTER_LABEL:-\{key = \"${OWNER}-eks-cluster\"\}}
 HELM_VERSION="${HELM_VERSION:-v3.1.1}"
 
 EKS_HOSTED_ZONE_NAME="${EKS_HOSTED_ZONE_NAME:-qa.aws.howdoi.website}"

--- a/backend/gke/defaults.sh
+++ b/backend/gke/defaults.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
+# Common options
+##################
+
+OWNER="${OWNER:-$(whoami)}"
+
 # GKE options
 #############
 
 GKE_PROJECT="${GKE_PROJECT:-suse-css-platform}"
 GKE_LOCATION="${GKE_LOCATION:-europe-west4-a}"
-GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-$(whoami)-cap}"
+GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-${OWNER}-cap}"
 GKE_CRED_JSON="${GKE_CRED_JSON:-}"
 GKE_DNSCRED_JSON="${GKE_DNSCRED_JSON:-${GKE_CRED_JSON}}"
 GKE_NODE_COUNT="${GKE_NODE_COUNT:-3}"

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -34,7 +34,7 @@ gke_sa_key     = "$GKE_CRED_JSON"
 gcp_dns_sa_key = "$GKE_DNSCRED_JSON"
 cluster_labels = {
     catapult-clustername = "$GKE_CLUSTER_NAME",
-    owner = "$(whoami)"
+    owner = "${OWNER}"
 }
 cluster_name   = "$GKE_CLUSTER_NAME"
 k8s_version    = "latest"


### PR DESCRIPTION
Allow override of the owner, rather than always forcing `$(whoami)` to be used.  This is useful for CI, where we can more properly identify the cluster rather than whatever user CI happens to run under.  This is also useful for cases where our login name does not match e.g. the GitHub identifier or similar.