### PR TITLE
fix: kubecf: Put LB DNS annotations in the config

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -312,27 +312,6 @@ external_dns_annotate_stratos() {
             "external-dns.alpha.kubernetes.io/hostname=console.${domain}, *.console.${domain}"
 }
 
-external_dns_annotate_kubecf() {
-    local ns=$1;shift
-    local domain=$1;shift
-    # for kubecf
-    kubectl annotate svc router-public \
-            -n "$ns" \
-            "external-dns.alpha.kubernetes.io/hostname=${domain}, *.${domain}"
-    if [[ "${ENABLE_EIRINI}" == true ]] ; then
-        kubectl annotate svc eirinix-ssh-proxy \
-                -n "$ns" \
-                "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
-    else
-        kubectl annotate svc ssh-proxy-public \
-            -n "$ns" \
-            "external-dns.alpha.kubernetes.io/hostname=ssh.${domain}"
-    fi
-    kubectl annotate svc tcp-router-public \
-            -n "$ns" \
-            "external-dns.alpha.kubernetes.io/hostname=*.tcp.${domain}, tcp.${domain}"
-}
-
 external_dns_annotate_scf() {
     local ns=$1;shift
     local domain=$1;shift

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -96,12 +96,18 @@ services:
   router:
     type: LoadBalancer
     externalIPs: [${external_ips}]
+    annotations:
+      "external-dns.alpha.kubernetes.io/hostname": "${domain}, *.${domain}"
   ssh-proxy:
     type: LoadBalancer
     externalIPs: [${external_ips}]
+    annotations:
+      "external-dns.alpha.kubernetes.io/hostname": "ssh.${domain}"
   tcp-router:
     type: LoadBalancer
     externalIPs: [${external_ips}]
+    annotations:
+      "external-dns.alpha.kubernetes.io/hostname": "*.tcp.${domain}, tcp.${domain}"
     port_range:
       start: 20000
       end: 20008

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -5,8 +5,6 @@
 . .envrc
 
 
-domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
-
 if [[ $ENABLE_EIRINI == true ]] ; then
    # [ ! -f "helm/cf/templates/eirini-namespace.yaml" ] && kubectl create namespace eirini
     if ! helm_ls 2>/dev/null | grep -qi metrics-server ; then

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -6,7 +6,6 @@
 
 
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
-services=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["services"]')
 
 if [[ $ENABLE_EIRINI == true ]] ; then
    # [ ! -f "helm/cf/templates/eirini-namespace.yaml" ] && kubectl create namespace eirini
@@ -118,8 +117,5 @@ helm_install susecf-scf ${SCF_CHART} \
 sleep 540
 
 wait_ns scf
-if [ "$services" == "lb" ]; then
-    external_dns_annotate_kubecf scf "$domain"
-fi
 
 ok "KubeCF deployed successfully"


### PR DESCRIPTION
Add the annotations required to set up DNS names for the load balancers into the helm values file we generate, so that we don't need to patch it afterwards.  However, we can't remove the patching yet as currently the Eirini chart has no way to attach extra annotations; we still need to do something better when Eirini is enabled so we can use ssh correctly.