### PR TITLE
fix: aks: force JSON output when getting kube vers

### DIFF
--- a/backend/aks/deploy.sh
+++ b/backend/aks/deploy.sh
@@ -19,7 +19,7 @@ if ! az account show; then
 fi
 
 # Check that KUBECTL_VERSION specified is available in azure location
-available_kube_versions=$(az aks get-versions -l "${AZURE_LOCATION}" | jq -c '[.orchestrators[] | select(.orchestratorType == "Kubernetes") | .orchestratorVersion]')
+available_kube_versions=$(az aks get-versions --output json -l "${AZURE_LOCATION}" | jq -c '[.orchestrators[] | select(.orchestratorType == "Kubernetes") | .orchestratorVersion]')
 if [[ -z $(jq 'index("'${KUBECTL_VERSION#v}'") // empty' <<< $available_kube_versions) ]]; then
     err "kubectl version ${KUBECTL_VERSION#v} not available in aks location ${AZURE_LOCATION}"
     info "Check KUBECTL_VERSION and AZURE_LOCATION settings"


### PR DESCRIPTION
Force the `az` CLI to produce JSON output when looking for kubernetes cluster versions; this is required if the user has changed the default (e.g. to table to be more readable).