### PR TITLE
Add python3-yamllint & shellcheck to catapult docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN curl -o install.py https://azurecliprod.blob.core.windows.net/install.py && 
   printf "/usr/local/lib/azure-cli\n/usr/local/bin\n\n\n" | python3 ./install.py && \
   rm ./install.py
 
+# KubeCF dependencies:
+RUN zypper in --no-recommends -y python3-yamllint shellcheck
+
 RUN zypper rm -y glibc-locale && zypper clean --all
 
 ADD . /catapult


### PR DESCRIPTION
This are the dependencies needed for KubeCF's `make lint`, and will allow the target to skip downloading them on CI.