### PR TITLE
turn off credhub tests for cats-eirini

### DIFF
--- a/modules/tests/kubecf-test.sh
+++ b/modules/tests/kubecf-test.sh
@@ -138,7 +138,7 @@ create_cats_internetless_secret() {
     kubectl get secret -n "${KUBECF_NAMESPACE}" "${cats_secret_name}" -o json  | \
     jq -r '.data."properties.yaml"' | base64 -d | \
     yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.include" '=internetless' | \
-    yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.credhub_mode" '"off"' | \
+    yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.credhub_mode" 'off' | \
     base64 -w 0 )"
 
   cats_updated="$(echo "$cats_secret" | yq w - 'data[properties.yaml]' $cats_updated_properties)"
@@ -220,7 +220,8 @@ SUITES
   cats_updated_properties="$(
     kubectl get secret -n "${KUBECF_NAMESPACE}" "${cats_secret_name}" -o json  | \
     jq -r '.data."properties.yaml"' | base64 -d | \
-    yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.include" "${suites}" |
+    yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.include" "${suites}" | \
+    yq w - "instance_groups.(name==acceptance-tests).jobs.(name==acceptance-tests).properties.acceptance_tests.credhub_mode" 'off' | \
     base64 -w 0 )"
 
   cats_updated="$(echo "$cats_secret" | yq w - 'data[properties.yaml]' $cats_updated_properties)"


### PR DESCRIPTION
This is according to the testing done here:
https://github.com/cloudfoundry-incubator/kubecf/issues/1007#issuecomment-656753374

Setting credhub_mode to `off` should set this:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/helpers/config/config_struct.go#L844
and this:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/helpers/config/config_struct.go#L848
to `false` and will skip credhub tests:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/cats_suite_helpers/cats_suite_helpers.go#L253

Consequently, the `diego` check is unneeded and that PR is here:
https://github.com/SUSE/cf-acceptance-tests/pull/2