### PR TITLE
Fix kubecf-chart target when passed a local file

### DIFF
--- a/modules/kubecf/chart.sh
+++ b/modules/kubecf/chart.sh
@@ -30,7 +30,7 @@ else
     if echo "$SCF_CHART" | grep -q "http"; then
         wget "$SCF_CHART" -O chart
     else
-        echo "fail?"
+        info "Grabbing chart from local file $CHART_URL"
         cp -rfv "$SCF_CHART" chart
     fi
 fi
@@ -43,6 +43,7 @@ if echo "$SCF_CHART" | grep -q "tgz"; then
 fi
 
 for file in *tgz; do
+    [ -f "$file" ] || continue # no file matches, skip
     tar -xvf "$file" -C ./
     rm -f "$file"
 done


### PR DESCRIPTION
Don't try to untar second tgz files if there is none (that would be the case of
kubecf bundles).

In the case of passing for example:
  SCF_CHART=/tmp/build/0a06c48c/helm-chart.kubecf-chart/kubecf-2.2.2.tgz
it already happens in a previous check.