### PR TITLE
Bump caasp4os backend from CaaSP 4.2 to CaaSP 4.5

### DIFF
--- a/backend/caasp4os/defaults.sh
+++ b/backend/caasp4os/defaults.sh
@@ -9,5 +9,5 @@ OWNER="${OWNER:-$(whoami)}"
 ##################
 
 CAASP_VER=${CAASP_VER:-"update"} # devel, staging, update, product
-KUBECTL_VERSION="${KUBECTL_VERSION:-v1.17.4}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.18.6}"
 HELM_VERSION="${HELM_VERSION:-v3.2.4}"

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -50,17 +50,17 @@ info "Injecting CAP terraform files…"
 
 case "$CAASP_VER" in
     "devel")
-        CAASP_REPO='caasp_40_devel_sle15sp1 = "http://ibs-mirror.prv.suse.net/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"'
+        CAASP_REPO='caasp_45_devel_sle15sp2 = "http://ibs-mirror.prv.suse.net/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/"'
          ;;
     "staging")
-        CAASP_REPO='caasp_40_staging_sle15sp1 = "http://ibs-mirror.prv.suse.net/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/"'
+        CAASP_REPO='caasp_45_staging_sle15sp2 = "http://ibs-mirror.prv.SUSE.net/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/CASP45/staging/"'
          ;;
     "product")
          # Already on terraform.tfvars
          CAASP_REPO=
          ;;
     "update")
-        CAASP_REPO='caasp_40_update_sle15sp1 = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/"',
+        CAASP_REPO='caasp_45_update_sle15sp2 = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SUSE-CAASP/4.5/x86_64/update/"',
          ;;
 esac
 escapeSubst() {

--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -20,9 +20,17 @@ RUN zypper --gpg-auto-import-keys ref -s
 
 # RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.5/x86_64/product/" caasp-product
 RUN zypper ar --no-gpgcheck "$IBS/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo"
+# For terraform package (they need ca-certificates installed already)
+RUN zypper ar --no-gpgcheck \
+  http://download.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/15-SP2/x86_64/product/ \
+  public-cloud
+RUN zypper ar \
+  --no-gpgcheck http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Public-Cloud/15-SP2/x86_64/update/ \
+  public-cloud-updates
 # RUN zypper ref
 RUN zypper in --auto-agree-with-licenses --no-confirm -t product caasp
 RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse openssh
+
 RUN zypper -n in -t pattern SUSE-CaaSP-Management
 RUN zypper up
 RUN zypper clean -a

--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1
+FROM registry.opensuse.org/opensuse/leap/15.2/images/totest/containers/opensuse/leap:15.2
 
 ARG VERSION
 ARG REPO_ENV
@@ -7,19 +7,19 @@ ARG REPO
 ARG IBS="http://download.suse.de/ibs"
 # ARG IBS="http://ibs-mirror.prv.suse.net/ibs"
 RUN for repo in SLE-Product-SLES SLE-Module-Basesystem SLE-Module-Containers; do \
-    zypper ar $IBS/SUSE/Products/$repo/15-SP1/x86_64/product ${repo}_pool; \
-    zypper ar $IBS/SUSE/Updates/$repo/15-SP1/x86_64/update ${repo}_updates; \
+    zypper ar $IBS/SUSE/Products/$repo/15-SP2/x86_64/product ${repo}_pool; \
+    zypper ar $IBS/SUSE/Updates/$repo/15-SP2/x86_64/update ${repo}_updates; \
 done
-RUN zypper ar $IBS/SUSE/Products/SUSE-CAASP/4.0/x86_64/product CAASP_pool
-# RUN zypper ar $IBS/Updates/SUSE-CAASP/4.0/x86_64/update CAASP_updates
+RUN zypper ar $IBS/SUSE/Products/SUSE-CAASP/4.5/x86_64/product CAASP_pool
+# RUN zypper ar $IBS/Updates/SUSE-CAASP/4.5/x86_64/update CAASP_updates
 RUN zypper ar --no-gpgcheck $IBS"${REPO}" "skuba-${REPO_ENV}"
 
 RUN zypper refresh; zypper -n dist-upgrade
 RUN zypper --gpg-auto-import-keys ref -s
 
 
-# RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/" caasp-product
-RUN zypper ar --no-gpgcheck "$IBS/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo"
+# RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.5/x86_64/product/" caasp-product
+RUN zypper ar --no-gpgcheck "$IBS/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo"
 # RUN zypper ref
 RUN zypper in --auto-agree-with-licenses --no-confirm -t product caasp
 RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse openssh

--- a/backend/caasp4os/docker/skuba/Makefile
+++ b/backend/caasp4os/docker/skuba/Makefile
@@ -1,15 +1,15 @@
 .PHONY: devel
 devel:
-	./build.sh devel /Devel:/CaaSP:/4.0/SLE_15_SP1/
+	./build.sh devel /Devel:/CaaSP:/4.5/SLE_15_SP2/
 
 .PHONY: staging
 staging:
-	./build.sh staging /SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/
+	./build.sh staging /SUSE:/SLE-15-SP2:/Update:/Products:/CASP45/staging/
 
 .PHONY: product
 product:
-	./build.sh product /SUSE/Products/SUSE-CAASP/4.0/x86_64/product/
+	./build.sh product /SUSE/Products/SUSE-CAASP/4.5/x86_64/product/
 
 .PHONY: update
 update:
-	./build.sh update /SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/
+	./build.sh update /SUSE/Updates/SUSE-CAASP/4.5/x86_64/update/

--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -2,7 +2,7 @@
 # EXAMPLE:
 # image_name = "SLE-15-SP1-JeOS-GMC"
 # JeOS needs default kernel for the nfs modules
-image_name = "SLES15-SP1-JeOS.x86_64-QU2"
+image_name = "SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM"
 
 # Name of the internal network to be created
 # EXAMPLE:
@@ -68,16 +68,16 @@ dnsentry = false
 #   repository2 = "http://example.my.repo.com/repository2/"
 # }
 repositories = {
-     #~placeholder_caasp_repo~#
-    "caasp_product" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/",
-    "suse_ca" = "http://ibs-mirror.prv.suse.net/ibs/SUSE:/CA/SLE_15_SP1/",
-    "sle_server_pool" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/",
-    "basesystem_pool" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
-    "containers_pool" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/",
-    "sle_server_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/",
-    "basesystem_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
-    "containers_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
-    "serverapps_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
+  #~placeholder_caasp_repo~#
+  "caasp_product"      = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SUSE-CAASP/4.5/x86_64/product/",
+  "suse_ca"            = "http://ibs-mirror.prv.suse.net/ibs/SUSE:/CA/SLE_15_SP2/",
+  "sle_server_pool"    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/",
+  "basesystem_pool"    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/",
+  "containers_pool"    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product/",
+  "sle_server_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+  "basesystem_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+  "containers_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+  "serverapps_updates" = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
 }
 
 # Minimum required packages. Do not remove them.

--- a/backend/caasp4os/terraform-os/terraform.tfvars.skel
+++ b/backend/caasp4os/terraform-os/terraform.tfvars.skel
@@ -94,7 +94,7 @@ packages = [
 #  "ssh-rsa <key-content>"
 # ]
 authorized_keys = [
-"#~placeholder_sshkey~#"
+  "#~placeholder_sshkey~#"
 ]
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure


### PR DESCRIPTION
- Bump to SLE 15 SP2, CaaSP 4.5.
- Add Public-Cloud SLE module to skuba image. In the next 2 weeks, the terraform package for the SUSE-CaaSP-Management pattern will come from there. There's no drawback in adding it now. Also, CaaSP automation has it already.
- Bump `KUBECTL_VERSION` on caasp4os/default.sh to v1.18.6
- Consume ECP SLE image `SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM`, which is not quarterly as it was before; we may need to bump it in the future.

Tested by deploying a CaaSP cluster on ECP, and checking that the both master and worker nodes have the correct repos and patterns installed, and skuba is `2.1.1`.