### PR TITLE
Simplify installation of SLE-Module-Public-Cloud

### DIFF
--- a/backend/caasp4os/docker/skuba/Dockerfile
+++ b/backend/caasp4os/docker/skuba/Dockerfile
@@ -6,7 +6,7 @@ ARG REPO
 
 ARG IBS="http://download.suse.de/ibs"
 # ARG IBS="http://ibs-mirror.prv.suse.net/ibs"
-RUN for repo in SLE-Product-SLES SLE-Module-Basesystem SLE-Module-Containers; do \
+RUN for repo in SLE-Product-SLES SLE-Module-Basesystem SLE-Module-Containers SLE-Module-Public-Cloud; do \
     zypper ar $IBS/SUSE/Products/$repo/15-SP2/x86_64/product ${repo}_pool; \
     zypper ar $IBS/SUSE/Updates/$repo/15-SP2/x86_64/update ${repo}_updates; \
 done
@@ -20,13 +20,6 @@ RUN zypper --gpg-auto-import-keys ref -s
 
 # RUN zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE/Products/SUSE-CAASP/4.5/x86_64/product/" caasp-product
 RUN zypper ar --no-gpgcheck "$IBS/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo"
-# For terraform package (they need ca-certificates installed already)
-RUN zypper ar --no-gpgcheck \
-  http://download.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/15-SP2/x86_64/product/ \
-  public-cloud
-RUN zypper ar \
-  --no-gpgcheck http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Public-Cloud/15-SP2/x86_64/update/ \
-  public-cloud-updates
 # RUN zypper ref
 RUN zypper in --auto-agree-with-licenses --no-confirm -t product caasp
 RUN zypper in --auto-agree-with-licenses --no-confirm ca-certificates-suse openssh


### PR DESCRIPTION
As says on the tin.

Tested by deleting the skuba/update docker image, recreating it, and deploying successfully a caasp4.5 cluster with it.