### PR TITLE
Explicitly set "install_stacks" in gen_config.sh for kubecf

### DIFF
--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -32,8 +32,15 @@ else
 INGRESS_BLOCK=''
 fi
 
+INSTALL_STACKS="[sle15, cflinuxfs3]"
+if [[ $ENABLE_EIRINI == true ]]; then
+    INSTALL_STACKS="[sle15]"
+fi
+
 cat > scf-config-values.yaml <<EOF
 system_domain: $domain
+
+install_stacks: ${INSTALL_STACKS}
 
 features:
   eirini:


### PR DESCRIPTION
Eirini will throw an error and refuse to install unless the default and only stack is set to sle15.