### PR TITLE
feat: Upgrade cf-operator too in kubecf-upgrade target

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -350,3 +350,29 @@ j2y() {
         ruby -r json -r yaml -e "puts YAML.dump(JSON.parse(ARGF.read))"
     fi
 }
+
+wait_for_cf-operator() {
+    # fixes operator readiness issue on AKS.
+    sleep 240
+
+    wait_ns cf-operator
+
+    wait_for "kubectl get endpoints -n cf-operator cf-operator-webhook -o name"
+    wait_for "kubectl get crd quarksstatefulsets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
+    wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
+    info "Test CRDs are ready"
+    #wait_for "kubectl apply -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl apply -f ../kube/cf-operator/password.yaml --namespace=scf"
+    if [[ "${DOCKER_REGISTRY}" == "registry.suse.com" ]]; then
+      # qstate_tolerations fails when internet connectivity is disabled.
+      wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
+    fi
+    wait_ns scf
+    #wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
+    wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
+    if [[ "${DOCKER_REGISTRY}" == "registry.suse.com" ]]; then
+      wait_for "kubectl delete -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
+    fi
+}

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -69,30 +69,11 @@ kubectl create namespace cf-operator || true
 
 helm_install cf-operator "${OPERATOR_CHART_URL}" --namespace cf-operator \
     "${operator_install_args[@]}"
-# fixes operator readiness issue on AKS.
-sleep 240
-
-wait_ns cf-operator
 
 info "Wait for cf-operator to be ready"
-wait_for "kubectl get endpoints -n cf-operator cf-operator-webhook -o name"
-wait_for "kubectl get crd quarksstatefulsets.quarks.cloudfoundry.org -o name"
-wait_for "kubectl get crd quarkssecrets.quarks.cloudfoundry.org -o name"
-wait_for "kubectl get crd quarksjobs.quarks.cloudfoundry.org -o name"
-wait_for "kubectl get crd boshdeployments.quarks.cloudfoundry.org -o name"
-info "Test CRDs are ready"
-#wait_for "kubectl apply -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
-wait_for "kubectl apply -f ../kube/cf-operator/password.yaml --namespace=scf"
-if [[ "${DOCKER_REGISTRY}" == "registry.suse.com" ]]; then
-  # qstate_tolerations fails when internet connectivity is disabled.
-  wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
-fi
-wait_ns scf
-#wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
-wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
-if [[ "${DOCKER_REGISTRY}" == "registry.suse.com" ]]; then
-  wait_for "kubectl delete -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
-fi
+
+wait_for_cf-operator
+
 ok "cf-operator ready"
 
 # KubeCF Doesn't support to setup a cluster password yet, doing it manually.

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -5,6 +5,20 @@
 . .envrc
 
 
+info "Upgrading CFO…"
+
+helm_upgrade cf-operator cf-operator/ \
+             --namespace cf-operator \
+             --reuse-values
+
+info "Wait for cf-operator to be ready"
+
+wait_for_cf-operator
+
+ok "cf-operator ready"
+
+info "Upgrading KubeCF…"
+
 if [ -n "$SCF_CHART" ]; then
 # save SCF_CHART on cap-values configmap
     kubectl patch -n kube-system configmap cap-values -p $'data:\n chart: "'$SCF_CHART'"'


### PR DESCRIPTION
Refactor cf-operator waiting code into `wait_for_cf-operator()`.
Upgrade cf-operator too in kubecf-upgrade target.

To be consumed by KubeCF's Concourse CI.

Tested several times on GKE and got successful upgrades; sometimes there's a race condition with the state of the database pod after cf-operator prompts changes to the deployment.
After upgrading cf-operator, the `cc-deployment-updater` of the scheduler pod gets stuck not ready. On the deployment-updater I get `DatabaseDisconnectError (…) Mysql2::Error: WSREP has not yet prepared node for application use`.
Nevertheless, this change needs to go in.