### PR TITLE
feat: AKS: allow explicit configuration of ssh key

### DIFF
--- a/backend/aks/defaults.sh
+++ b/backend/aks/defaults.sh
@@ -24,6 +24,9 @@ AZURE_DNS_JSON="${AZURE_DNS_JSON:-}"
 AZURE_DNS_RESOURCE_GROUP="${AZURE_DNS_RESOURCE_GROUP:-susecap-domain}"
 AZURE_DNS_DOMAIN="${AZURE_DNS_DOMAIN:-${AZURE_CLUSTER_NAME}.susecap.net}"
 
+# Optional: SSH key file for Azure to use.  If unset, take first in SSH agent.
+AZURE_SSH_KEY="${AZURE_SSH_KEY:-}"
+
 # Settings for terraform state save/restore
 #
 # Set to a non-empty key to trigger state save in deploy.sh.

--- a/backend/aks/deploy.sh
+++ b/backend/aks/deploy.sh
@@ -37,8 +37,14 @@ export ARM_TENANT_ID="${AZURE_TENANT_ID}"
 pushd cap-terraform/aks || exit
 # ssh_public_key needs to be a file. Build it regardless of {ssh,gpg}-agent, or
 # forwarding of agents:
-ssh-add -L
-(ssh-add -L | head -n 1) > ./sshkey.pub
+if [[ -n "${AZURE_SSH_KEY:-}" ]]; then
+  test -r "${AZURE_SSH_KEY}"
+  ssh-add -L | grep --silent -F "$(ssh-keygen -y -f "${AZURE_SSH_KEY}")"
+  ssh-keygen -y -f "${AZURE_SSH_KEY}" > ./sshkey.pub
+else
+  ssh-add -L
+  (ssh-add -L | head -n 1) > ./sshkey.pub
+fi
 
 terraform init
 


### PR DESCRIPTION
This allows an explicit SSH key to be used, rather than whatever is the first in the ssh agent.

This is useful if the first key in the keychain isn't accepted by Azure (e.g. I don't think they like ed25519 yet).

The existing behaviour is unchanged.