### PR TITLE
fix: AKS: don't die on cleanup if we have no kube

### DIFF
--- a/backend/aks/clean.sh
+++ b/backend/aks/clean.sh
@@ -16,7 +16,7 @@ if [ -d "$BUILD_DIR" ]; then
     export ARM_TENANT_ID="${AZURE_TENANT_ID}"
 
     pushd cap-terraform/aks || exit
-    if [[ ! -f aksk8scfg ]]; then
+    if [[ -f "${KUBECONFIG}" && ! -f aksk8scfg ]]; then
         cp "${KUBECONFIG}" aksk8scfg
     fi
     terraform init


### PR DESCRIPTION
Previously, we were unable to clean up a half-deployed kube cluster (because the kubeconfig file was missing).  That's not helpful as a cleanup step.

We don't _really_ need the kubeconfig to delete the cluster…