### PR TITLE
fix: Reduce cf-o wait sleep from 240 to 10

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -352,8 +352,7 @@ j2y() {
 }
 
 wait_for_cf-operator() {
-    # fixes operator readiness issue on AKS.
-    sleep 240
+    sleep 10
 
     wait_ns cf-operator
 


### PR DESCRIPTION
Change introduced in:
https://github.com/SUSE/catapult/commit/fc8e007992bafd9f06dd37638e92e4128de0f938