### PR TITLE
fix: Bump cf to 7.1.0 in helper bins

### DIFF
--- a/modules/common/deps.sh
+++ b/modules/common/deps.sh
@@ -44,9 +44,9 @@ else
     fi
 
     if [ ! -e "bin/cf" ]; then
-        curl -sSL "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&source=github" | tar -zx
-        mv cf bin/
-        rm -rf "$CFCLI_OS_TYPE" LICENSE NOTICE
+        curl -sSL "https://packages.cloudfoundry.org/stable?release=${CFCLI_OS_TYPE}-binary&version=7.1.0&source=github" | tar -zx
+        rm -rf "$CFCLI_OS_TYPE" cf LICENSE NOTICE
+        mv cf7 bin/cf
         chmod +x bin/cf
         info "CF cli version:"
         cf version


### PR DESCRIPTION
This has no effect on testing, cf version used comes is bundled in the bosh
releases.