### PR TITLE
feat: Add kubeconfig target to minikube backend

### DIFF
--- a/backend/minikube/Makefile
+++ b/backend/minikube/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: kubeconfig
 kubeconfig:
-	# No-op
+	./kubeconfig.sh
 
 .PHONY: clean
 clean:

--- a/backend/minikube/kubeconfig.sh
+++ b/backend/minikube/kubeconfig.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. ../../include/common.sh
+. .envrc
+
+if [ ! -f kubeconfig ]; then
+    cp "$KUBECFG" kubeconfig
+
+    ok "Kubeconfig copied"
+fi


### PR DESCRIPTION
It helps in importing a minikube cluster, but you will need to set up the DOMAIN
var on your own for now.