### PR TITLE
Increase pid_limit to 4096 in caasp4os

### DIFF
--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -107,6 +107,10 @@ wait
 # skuba_reboots disable
 # wait
 
+info "Raising pid_limits for crio…"
+skuba_raise_pid_limit all
+wait
+
 # Create k8s configmap
 PUBLIC_IP="$(skuba_container terraform output -json | jq -r '.ip_load_balancer.value|to_entries|map(.value)|first')"
 ROOTFS=overlay-xfs

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -104,6 +104,8 @@ info "Disabling node updates…"
 skuba_updates all disable
 wait
 
+# reboots commented, no updates to trigger them
+# info "Disabling node reboots …"
 # skuba_reboots disable
 # wait
 

--- a/backend/caasp4os/lib/skuba.sh
+++ b/backend/caasp4os/lib/skuba.sh
@@ -160,6 +160,23 @@ skuba_updates() {
     done
 }
 
+skuba_raise_pid_limit() {
+    # Usage:
+    # skuba_raise_pid_limit <target>
+    # skuba_raise_pid_limit all
+
+    # from https://confluence.suse.com/pages/viewpage.action?pageId=565905160
+    # setting pids_limit = 4096 which is the default number for services
+
+    local target="${1:-all}"
+    local action="${2:-disable}"
+
+    _define_node_group "$target"
+    for n in $GROUP; do
+        _ssh2 "$n" "echo 'pids_limit = 4096 # max num proc in container' | sudo tee /etc/crio/crio.conf.d/02-cap.conf && sudo systemctl restart crio"
+    done
+}
+
 _init_control_plane() {
     skuba_container skuba cluster init \
                     --cloud-provider openstack \


### PR DESCRIPTION
This implements all relevant improvements from:
  https://confluence.suse.com/pages/viewpage.action?pageId=565905160

The only relevant one for Openstack is raising the pid_limit (max number of
processes inside 1 container) from 1024 to 4096 (default number for systemd
services).

Rest of improvements are about raising the node pid, fproc, etc limits, which in
Openstack we achieve by selecting a big enough flavour image.