### PR TITLE
Add default `services` key on cap-values when creating a cluster.

### DIFF
--- a/backend/aks/deploy.sh
+++ b/backend/aks/deploy.sh
@@ -75,6 +75,7 @@ wait_for 'PUBLIC_IP="$(kubectl get services nginx-ingress-nginx-ingress-controll
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=garden-rootfs-driver="${ROOTFS}" \
+            --from-literal=services="lb" \
             --from-literal=public-ip="${PUBLIC_IP}" \
             --from-literal=domain="${AZURE_DNS_DOMAIN}" \
             --from-literal=platform=aks

--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -115,6 +115,7 @@ DOMAIN="$PUBLIC_IP"."$MAGICDNS"
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=services="hardcoded" \
             --from-literal=domain="${DOMAIN}" \
             --from-literal=garden-rootfs-driver="${ROOTFS}" \
             --from-literal=platform=caasp4

--- a/backend/ekcp/prepare.sh
+++ b/backend/ekcp/prepare.sh
@@ -133,6 +133,7 @@ info "Domain: $domain"
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=public-ip="${container_ip}" \
+            --from-literal=services="hardcoded" \
             --from-literal=domain="$domain" \
             --from-literal=platform="ekcp"
 fi

--- a/backend/eks/deploy.sh
+++ b/backend/eks/deploy.sh
@@ -38,6 +38,7 @@ if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; the
     kubectl create configmap -n kube-system cap-values \
             --from-literal=garden-rootfs-driver="${ROOTFS}" \
             --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=services="lb" \
             --from-literal=domain="${EKS_DOMAIN}" \
             --from-literal=platform=eks
 fi

--- a/backend/gke/deploy.sh
+++ b/backend/gke/deploy.sh
@@ -51,6 +51,7 @@ if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; the
     kubectl create configmap -n kube-system cap-values \
             --from-literal=garden-rootfs-driver="${ROOTFS}" \
             --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=services="lb" \
             --from-literal=domain="${GKE_DNSDOMAIN}" \
             --from-literal=platform=gke
 fi

--- a/backend/kind/prepare.sh
+++ b/backend/kind/prepare.sh
@@ -135,6 +135,7 @@ domain="${container_ip}.$MAGICDNS"
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=public-ip="${container_ip}" \
+            --from-literal=services="hardcoded" \
             --from-literal=domain="$domain" \
             --from-literal=platform="kind"
 fi

--- a/backend/minikube/prepare.sh
+++ b/backend/minikube/prepare.sh
@@ -33,6 +33,7 @@ domain="${container_ip}.$MAGICDNS"
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=public-ip="${container_ip}" \
+            --from-literal=services="lb" \
             --from-literal=domain="$domain" \
             --from-literal=platform="minikube"
 fi

--- a/modules/kubecf/defaults.sh
+++ b/modules/kubecf/defaults.sh
@@ -13,7 +13,7 @@ OPERATOR_CHART_URL="${OPERATOR_CHART_URL:-latest}"
 
 # kubecf-gen-config relevant:
 
-SCF_SERVICES="${SCF_SERVICES:-lb}" # lb, ingress
+KUBECF_SERVICES="${KUBECF_SERVICES:-}" # empty, lb, ingress, hardcoded. If not empty, overwrites the cluster's cap-values "services"
 GARDEN_ROOTFS_DRIVER="${GARDEN_ROOTFS_DRIVER:-overlay-xfs}"
 DIEGO_SIZING="${DIEGO_SIZING:-$SIZING}"
 STORAGECLASS="${STORAGECLASS:-persistent}"

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -11,8 +11,9 @@ if [ -z "$KUBECF_SERVICES" ]; then
     services=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["services"]')
 fi
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
-if [ "$services" == ingress ]; then
-INGRESS_BLOCK="ingress:
+
+if [ "${services}" == "ingress" ]; then
+    INGRESS_BLOCK="ingress:
     enabled: true
     tls:
       crt: ~
@@ -21,7 +22,7 @@ INGRESS_BLOCK="ingress:
     labels: {}
 "
 else
-INGRESS_BLOCK=''
+    INGRESS_BLOCK=''
 fi
 
 if [ "${services}" == "hardcoded" ]; then

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -9,6 +9,9 @@ rm -f scf-config-values.yaml
 
 if [ -z "$KUBECF_SERVICES" ]; then
     services=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["services"]')
+else
+    # KUBECF_SERVICES not empty, we want to override then:
+    services="$KUBECF_SERVICES"
 fi
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 

--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -6,8 +6,9 @@
 
 info "Generating KubeCF config values"
 
-kubectl patch -n kube-system configmap cap-values -p $'data:\n services: "'$SCF_SERVICES'"'
-services="$SCF_SERVICES"
+if [ -n "$KUBECF_SERVICES" ]; then
+    services=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["services"]')
+fi
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
 array_external_ips=()


### PR DESCRIPTION
Set a `services` key on cap-values when creating a cluster.

It informs on the type of service termination the cluster has:
- lb.
- ingress.
- hardcoded: use the public ip of the nodes.

This gets used in `modules/kubecf/gen-config.sh` to construct the correct `values.yaml`.

One can overwrite it by setting `KUBECF_SERVICES`, see `modules/kubecf/defaults.sh`.