### PR TITLE
remove default kubecf cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ kubecf-clean: ##@kubecf Only delete installation of KubeCF & related files
 	$(MAKE) -C modules/kubecf clean
 
 .PHONY: kubecf
-kubecf: ##@STATES Delete if exists then deploy KubeCF in cluster
+kubecf: ##@STATES Does not delete if exists. Deploys KubeCF in cluster
 	$(MAKE) -C modules/kubecf
 
 .PHONY: kubecf-chart

--- a/modules/kubecf/Makefile
+++ b/modules/kubecf/Makefile
@@ -1,9 +1,5 @@
 .DEFAULT_GOAL := all
 
-.PHONY: clean
-clean:
-	./clean.sh
-
 .PHONY: chart
 chart:
 	./chart.sh
@@ -25,9 +21,13 @@ purge:
 	./purge.sh
 
 .PHONY: all
-all: clean chart gen-config install
+all: chart gen-config install
 
 ## one-offs:
+
+.PHONY: clean
+clean:
+	./clean.sh
 
 .PHONY: precheck
 precheck:


### PR DESCRIPTION
fixes https://github.com/SUSE/catapult/issues/295

kubecf clean should not be a default if kubecf install. Cleanup should only happen when explicitly asked for by a user.

Test: https://concourse.suse.dev/teams/main/pipelines/prabal-gke-upgrades/jobs/pre-upgrade-deploy-kubecf-diego-gke-sa/builds/9

```
[prabal:~/gop/src/github.com/SUSE/cap/cap-ci] master(+8/-8)* 12s ± fly -t concourse.suse.dev hijack --job prabal-gke-upgrades/pre-upgrade-deploy-kubecf-diego-gke-sa

0a96fac2-4518-48a4-5556-5c904c2ec3b6:/tmp/build/0a06c48c # source catapult/buildprabal-gke/.envrc 
0a96fac2-4518-48a4-5556-5c904c2ec3b6:/tmp/build/0a06c48c # kubectl get configmap -n kube-system cap-values -o json
{
    "apiVersion": "v1",
    "data": {
        "chart": "/tmp/build/0a06c48c/helm-chart.kubecf-chart/kubecf-2.2.3.tgz",
        "domain": "prabal-gke.ci.kubecf.charmedquarks.me",
        "garden-rootfs-driver": "overlay-xfs",
        "platform": "gke",
        "public-ip": "10.164.0.62",
        "services": "lb"
    },
    "kind": "ConfigMap",
    "metadata": {
        "creationTimestamp": "2020-10-05T23:07:59Z",
        "name": "cap-values",
        "namespace": "kube-system",
        "resourceVersion": "11634",
        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cap-values",
        "uid": "e3706e02-6204-44db-8ebe-b3afa9ef0cad"
    }
}

0a96fac2-4518-48a4-5556-5c904c2ec3b6:/tmp/build/0a06c48c # cat catapult/buildprabal-gke/scf-config-values.yaml
---
services:
  router:
    type: LoadBalancer
    externalIPs: []
    annotations:
      external-dns.alpha.kubernetes.io/hostname: prabal-gke.ci.kubecf.charmedquarks.me,
        *.prabal-gke.ci.kubecf.charmedquarks.me
  ssh-proxy:
    type: LoadBalancer
    externalIPs: []
    annotations:
      external-dns.alpha.kubernetes.io/hostname: ssh.prabal-gke.ci.kubecf.charmedquarks.me
  tcp-router:
    type: LoadBalancer
    externalIPs: []
    annotations:
      external-dns.alpha.kubernetes.io/hostname: "*.tcp.prabal-gke.ci.kubecf.charmedquarks.me,
        tcp.prabal-gke.ci.kubecf.charmedquarks.me"
    port_range:
      start: 20000
      end: 20008
system_domain: prabal-gke.ci.kubecf.charmedquarks.me
install_stacks:
- sle15
- cflinuxfs3
features:
  eirini:
    enabled: false
  autoscaler:
    enabled: false
high_availability: false
testing:
  brain_tests:
    enabled: true
  cf_acceptance_tests:
    enabled: true
  smoke_tests:
    enabled: true
  sync_integration_tests:
    enabled: true
properties:
  acceptance-tests:
    acceptance-tests:
      acceptance_tests:
        timeout_scale: 3
        ginkgo:
          slow_spec_threshold: 300
          extra_flags: ''
          nodes: 3
          flake_attempts: 5
  brain-tests:
    acceptance-tests-brain:
      acceptance_tests_brain:
        verbose: 'false'
        in_order: 'false'
        include: ''
        exclude: ''
0a96fac2-4518-48a4-5556-5c904c2ec3b6:/tmp/build/0a06c48c # 
```