### PR TITLE
Don't delete `services` on cap-values anymore

### DIFF
--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -55,10 +55,4 @@ if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.da
     kubectl patch -n kube-system configmap cap-values --type json -p '[{"op": "remove", "path": "/data/chart"}]'
 fi
 
-# delete SCF_SERVICES on cap-values configmap
-if [[ -n "$(kubectl get -o json -n kube-system configmap cap-values | jq -r '.data.services // empty')" ]]; then
-    kubectl patch -n kube-system configmap cap-values --type json \
-            -p '[{"op": "remove", "path": "/data/services"}]'
-fi
-
 ok "Cleaned up KubeCF from the k8s cluster"


### PR DESCRIPTION
"services", as "domain" in the cap-values, are part of the cluster environment.
Not something you can easily change on a whim when deploying kubecf.

If one wants to change it, one needs a different cluster creation.

Fixes https://github.com/SUSE/catapult/issues/295, introduced with https://github.com/SUSE/catapult/pull/294.