### PR TITLE
Fix minikube deployments

### DIFF
--- a/backend/minikube/clean.sh
+++ b/backend/minikube/clean.sh
@@ -8,7 +8,7 @@ if [ -d "$BUILD_DIR" ]; then
     # minikube uses retcodes to codify in binary the status of minikube, cluster, and kubernetes
     # Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for kubernetes NOK)
     set +x
-    minikube delete || true
+    minikube delete --profile "$CLUSTER_NAME" || true
     set -x
     popd || exit
 

--- a/backend/minikube/deps.sh
+++ b/backend/minikube/deps.sh
@@ -8,7 +8,7 @@ if [[ "$DOWNLOAD_CATAPULT_DEPS" == "false" ]]; then
     exit 0
 fi
 
-MINIKUBE_VERSION=latest
+MINIKUBE_VERSION="v1.9.2" # or latest, for example
 if [[ "$OSTYPE" == "darwin"* ]]; then
     MINIKUBE_BIN=minikube-darwin-amd64
 else

--- a/backend/minikube/prepare.sh
+++ b/backend/minikube/prepare.sh
@@ -11,7 +11,7 @@ domain="${container_ip}.$MAGICDNS"
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
     kubectl create configmap -n kube-system cap-values \
             --from-literal=public-ip="${container_ip}" \
-            --from-literal=services="lb" \
             --from-literal=domain="$domain" \
+            --from-literal=services="hardcoded" \
             --from-literal=platform="minikube"
 fi

--- a/backend/minikube/prepare.sh
+++ b/backend/minikube/prepare.sh
@@ -5,7 +5,7 @@
 
 helm_init
 
-container_ip=$(minikube ip)
+container_ip=$(minikube ip --profile "$CLUSTER_NAME")
 domain="${container_ip}.$MAGICDNS"
 
 if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then

--- a/backend/minikube/prepare.sh
+++ b/backend/minikube/prepare.sh
@@ -3,28 +3,6 @@
 . ../../include/common.sh
 . .envrc
 
-kubectl create clusterrolebinding admin --clusterrole=cluster-admin --user=system:serviceaccount:kube-system:default
-kubectl create clusterrolebinding uaaadmin --clusterrole=cluster-admin --user=system:serviceaccount:uaa:default
-kubectl create clusterrolebinding scfadmin --clusterrole=cluster-admin --user=system:serviceaccount:scf:default
-
-cat > storageclass.yaml <<EOF
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
-  name: persistent
-  resourceVersion: "352"
-  selfLink: /apis/storage.k8s.io/v1/storageclasses/standard
-provisioner: k8s.io/minikube-hostpath
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
-EOF
-
-kubectl create -f ./storageclass.yaml
-kubectl delete storageclass standard
 helm_init
 
 container_ip=$(minikube ip)

--- a/backend/minikube/start.sh
+++ b/backend/minikube/start.sh
@@ -5,4 +5,4 @@
 . .envrc
 
 
-minikube start
+minikube start --profile "$CLUSTER_NAME"

--- a/backend/minikube/stop.sh
+++ b/backend/minikube/stop.sh
@@ -4,4 +4,4 @@
 . .envrc
 
 
-minikube stop
+minikube stop --profile "$CLUSTER_NAME"


### PR DESCRIPTION
Change MINIKUBE_VERSION to v1.9.2.
Use same minikube options and iso as scripts/kubecf.
Don't set rolebindings or storageclass, not needed.
Set `services=hardcoded` on minikube, to use the public ip as domain.