### PR TITLE
Fixes for caasp4.5 in BACKEND=caasp4os

### DIFF
--- a/backend/caasp4os/deploy.sh
+++ b/backend/caasp4os/deploy.sh
@@ -79,7 +79,7 @@ sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
 # enable cpi
 sed -i '/cpi_enable/s/^#//g' deployment/cpi.auto.tfvars
 # inject our terraform files
-cp -r "$ROOT_DIR"/backend/caasp4os/terraform-os/* deployment/
+cp -rf "$ROOT_DIR"/backend/caasp4os/terraform-os/* deployment/
 
 pushd deployment || exit
 

--- a/backend/caasp4os/destroy.sh
+++ b/backend/caasp4os/destroy.sh
@@ -25,10 +25,10 @@ if [ -d "$BUILD_DIR" ]; then
         if [[ ! -v OS_PASSWORD ]]; then
             err "Missing openstack credentials" && exit 1
         fi
+        skuba_container terraform init
         skuba_container terraform destroy -auto-approve
         info "Terraform infrastructure destroyed"
         # TODO see deployment/my-cluster/cloud/
-        # TODO one needs to manually delete cinder volumes and LB
         # TODO external-dns will fail to delete DNS entries
         # https://github.com/kubernetes-sigs/external-dns/pull/1255
         popd || exit

--- a/backend/caasp4os/prepare.sh
+++ b/backend/caasp4os/prepare.sh
@@ -84,7 +84,7 @@ HEREDOC
 }
 
 
-create_rolebinding
+# create_rolebinding
 install_helm_and_tiller
 create_cpi_storageclass
 


### PR DESCRIPTION
Always inject terraform files.
Call terraform init from skuba image when destroying, to fix error of uninitialized terraform plugins.
Don't set up any RBAC or psp for now, use the default caasp psp. Kubecf ships and applies its own psps, so it is no problem.