### PR TITLE
Add workaround for upgrade of cap-2.1.0-rc2

### DIFF
--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -4,6 +4,8 @@
 . ../../include/common.sh
 . .envrc
 
+. "$ROOT_DIR"/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
+
 info "Upgrading CFO…"
 helm list -A
 

--- a/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
+++ b/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+info "WORKAROUND CAP 2.1.0-rc2"
+kubectl delete qjob --namespace scf dm


### PR DESCRIPTION
Add a folder /modules/kubecf/workarounds/ that will contain all workarounds to
be applied.

Apply workarounds/pre-upgrade-cap-2.1.0-rc2.sh before upgrade process.