### PR TITLE
Fix tls key name and suppress trailing newline

### DIFF
--- a/modules/kubecf/gen_config.sh
+++ b/modules/kubecf/gen_config.sh
@@ -146,16 +146,16 @@ EOF
 )
     # save ingress cert and key to file
     kubectl get configmap -n kube-system cap-values -o json | \
-        jq -r '.data["ingress-cert"]' \
+        jq -j '.data["ingress-cert"]' \
            > ingress-cert
     kubectl get configmap -n kube-system cap-values -o json | \
-        jq -r '.data["ingress-cert-key"]' \
-           > ingress-cert-key
+        jq -j '.data["ingress-key"]' \
+           > ingress-key
     # add ingress block
     scf_config_values=$(jq --compact-output --null-input "${scf_config_values} * ${ingress_block}")
     # patch values json with cert and key from file
     scf_config_values=$(echo "$scf_config_values" | jq --compact-output --rawfile crt ./ingress-cert '.features.ingress.tls.crt=$crt')
-    scf_config_values=$(echo "$scf_config_values" | jq --compact-output --rawfile key ./ingress-cert-key '.features.ingress.tls.key=$key')
+    scf_config_values=$(echo "$scf_config_values" | jq --compact-output --rawfile key ./ingress-key '.features.ingress.tls.key=$key')
 fi
 
 


### PR DESCRIPTION
Expects the following key names in configmap, for ingress tls:

```
data:
  ingress-cert: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
  ingress-key: |
    -----BEGIN RSA PRIVATE KEY-----
    ...
    -----END RSA PRIVATE KEY-----
  services: ingress

When those are read from configmap, `jq -j` will enter rawmode, but suppress a trailing newline in the output