### PR TITLE
Add wait-autoscaler-dns-clbo-cap-2.1.0-rc2.s workaround

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -215,6 +215,7 @@ function wait_ns {
     while ! ( kubectl get pods --namespace "$1" | gawk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
     do
         sleep 10
+        . "$ROOT_DIR"/modules/kubecf/workarounds/wait-autoscaler-dns-clbo-cap-2.1.0-rc2.sh
     done
 }
 

--- a/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
+++ b/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
-info "WORKAROUND CAP 2.1.0-rc2"
+info "Applying WORKAROUND $(basename ${BASH_SOURCE[0]})"
+set +x # print workaround
+
 kubectl delete qjob --namespace scf dm
+
+debug_mode # reset printing option

--- a/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
+++ b/modules/kubecf/workarounds/pre-upgrade-cap-2.1.0-rc2.sh
@@ -3,6 +3,6 @@
 info "Applying WORKAROUND $(basename ${BASH_SOURCE[0]})"
 set +x # print workaround
 
-kubectl delete qjob --namespace scf dm
+kubectl delete qjob --namespace scf dm --ignore-not-found
 
 debug_mode # reset printing option

--- a/modules/kubecf/workarounds/wait-autoscaler-dns-clbo-cap-2.1.0-rc2.sh
+++ b/modules/kubecf/workarounds/wait-autoscaler-dns-clbo-cap-2.1.0-rc2.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ $(yq r scf-config-values.yaml features.autoscaler.enabled) == "true" ]]; then
+    for pod in $(kubectl get pods -n scf --output=jsonpath={.items..metadata.name} | \
+                     grep -E --only-matching 'asactors-[0-9]*|asapi-[0-9]*');
+    do
+        if kubectl get pods -n scf $pod | grep -qi CrashLoopBackOff; then
+            info "Applying WORKAROUND $(basename ${BASH_SOURCE[0]})"
+            set +x # print workaround
+            kubectl delete pod $pod --namespace scf
+            debug_mode # reset printing option
+        fi
+    done
+fi


### PR DESCRIPTION
Adds `wait-autoscaler-dns-clbo-cap-2.1.0-rc2.sh` workaround in wait_ns that:
if in, autoscaler, and any pods starting with `asactors` or `asapi` are in CLBO, then delete them.

Prettify workaround `pre-upgrade-cap-2.1.0-rc2.sh`.