### PR TITLE
feat: GKE: Allow adding extra labels

### DIFF
--- a/backend/gke/defaults.sh
+++ b/backend/gke/defaults.sh
@@ -20,6 +20,9 @@ GKE_DNSDOMAIN="${GKE_DNSDOMAIN:-${GKE_CLUSTER_NAME}.ci.kubecf.charmedquarks.me}"
 # Instance type of the nodes: empty string for terraform's default, or for example n1-highcpu-16 for 1-node cluster
 GKE_INSTANCE_TYPE="${GKE_INSTANCE_TYPE:-}"
 
+# Extra labels to attach to clusters, in terraform syntax.
+EXTRA_LABELS="${EXTRA_LABELS:-}"
+
 # Settings for terraform state save/restore
 #
 # Set to a non-empty key to trigger state save in deploy.sh.

--- a/backend/gke/defaults.sh
+++ b/backend/gke/defaults.sh
@@ -20,7 +20,7 @@ GKE_DNSDOMAIN="${GKE_DNSDOMAIN:-${GKE_CLUSTER_NAME}.ci.kubecf.charmedquarks.me}"
 # Instance type of the nodes: empty string for terraform's default, or for example n1-highcpu-16 for 1-node cluster
 GKE_INSTANCE_TYPE="${GKE_INSTANCE_TYPE:-}"
 
-# Extra labels to attach to clusters, in terraform syntax.
+# Extra labels to attach to clusters, in JSON syntax (e.g. `{"foo":"bar"}`).
 EXTRA_LABELS="${EXTRA_LABELS:-}"
 
 # Settings for terraform state save/restore

--- a/backend/gke/tfsetup.sh
+++ b/backend/gke/tfsetup.sh
@@ -28,6 +28,7 @@ gcp_dns_sa_key = "$GKE_DNSCRED_JSON"
 cluster_labels = {
     catapult-clustername = "$GKE_CLUSTER_NAME",
     owner = "${OWNER}"
+    ${EXTRA_LABELS}
 }
 cluster_name   = "$GKE_CLUSTER_NAME"
 k8s_version    = "latest"

--- a/backend/gke/tfsetup.sh
+++ b/backend/gke/tfsetup.sh
@@ -38,12 +38,14 @@ HEREDOC
 
 if [ -n "${EXTRA_LABELS}" ] ; then
     jq --raw-output --argjson labels "${EXTRA_LABELS}" '.cluster_labels *= $labels' terraform.tfvars.json \
-        | sponge terraform.tfvars.json
+        > terraform.tfvars.temp.json
+    mv terraform.tfvars.temp.json terraform.tfvars.json
 fi
 
 if [ -n "${GKE_INSTANCE_TYPE}" ] ; then
     jq --argjson type "${GKE_INSTANCE_TYPE}" '.instance_type = $type' terraform.tfvars.json \
-        | sponge terraform.tfvars.json
+        > terraform.tfvars.temp.json
+    mv terraform.tfvars.temp.json terraform.tfvars.json
 fi
 
 if [ -n "${TF_KEY}" ] ; then

--- a/backend/gke/tfsetup.sh
+++ b/backend/gke/tfsetup.sh
@@ -17,31 +17,33 @@ git checkout "${CAP_TERRAFORM_BRANCH}"
 git pull
 
 # Clear out any existing variables file
-echo "" > terraform.tfvars.json
-yq merge --inplace --tojson --prettyPrint terraform.tfvars.json - <<HEREDOC
-project        : "$GKE_PROJECT"
-location       : "$GKE_LOCATION"
-node_pool_name : "$GKE_CLUSTER_NAME"
-instance_count : "$GKE_NODE_COUNT"
-preemptible    : "$GKE_PREEMPTIBLE"
-vm_type        : "UBUNTU"
-gke_sa_key     : "$GKE_CRED_JSON"
-gcp_dns_sa_key : "$GKE_DNSCRED_JSON"
-cluster_labels :
-    catapult-clustername: "$GKE_CLUSTER_NAME"
-    owner : "${OWNER}"
-cluster_name   : "$GKE_CLUSTER_NAME"
-k8s_version    : "latest"
+cat > terraform.tfvars.json <<HEREDOC
+{
+    "project"        : "$GKE_PROJECT",
+    "location"       : "$GKE_LOCATION",
+    "node_pool_name" : "$GKE_CLUSTER_NAME",
+    "instance_count" : "$GKE_NODE_COUNT",
+    "preemptible"    : "$GKE_PREEMPTIBLE",
+    "vm_type"        : "UBUNTU",
+    "gke_sa_key"     : "$GKE_CRED_JSON",
+    "gcp_dns_sa_key" : "$GKE_DNSCRED_JSON",
+    "cluster_labels" : {
+        "catapult-clustername": "$GKE_CLUSTER_NAME",
+        "owner" : "${OWNER}"
+    },
+    "cluster_name"   : "$GKE_CLUSTER_NAME",
+    "k8s_version"    : "latest"
+}
 HEREDOC
 
 if [ -n "${EXTRA_LABELS}" ] ; then
-    yq merge --inplace --tojson --prettyPrint --overwrite terraform.tfvars.json \
-        - <<< "cluster_labels: ${EXTRA_LABELS}"
+    jq --raw-output --argjson labels "${EXTRA_LABELS}" '.cluster_labels *= $labels' terraform.tfvars.json \
+        | sponge terraform.tfvars.json
 fi
 
 if [ -n "${GKE_INSTANCE_TYPE}" ] ; then
-    yq write --inplace --tojson --prettyPrint terraform.tfvars.json \
-        instance_type "${GKE_INSTANCE_TYPE}"
+    jq --argjson type "${GKE_INSTANCE_TYPE}" '.instance_type = $type' terraform.tfvars.json \
+        | sponge terraform.tfvars.json
 fi
 
 if [ -n "${TF_KEY}" ] ; then

--- a/backend/gke/tfsetup.sh
+++ b/backend/gke/tfsetup.sh
@@ -16,28 +16,32 @@ pushd cap-terraform/gke || exit
 git checkout "${CAP_TERRAFORM_BRANCH}"
 git pull
 
-cat <<HEREDOC > terraform.tfvars
-project        = "$GKE_PROJECT"
-location       = "$GKE_LOCATION"
-node_pool_name = "$GKE_CLUSTER_NAME"
-instance_count = "$GKE_NODE_COUNT"
-preemptible    = "$GKE_PREEMPTIBLE"
-vm_type        = "UBUNTU"
-gke_sa_key     = "$GKE_CRED_JSON"
-gcp_dns_sa_key = "$GKE_DNSCRED_JSON"
-cluster_labels = {
-    catapult-clustername = "$GKE_CLUSTER_NAME",
-    owner = "${OWNER}"
-    ${EXTRA_LABELS}
-}
-cluster_name   = "$GKE_CLUSTER_NAME"
-k8s_version    = "latest"
+# Clear out any existing variables file
+echo "" > terraform.tfvars.json
+yq merge --inplace --tojson --prettyPrint terraform.tfvars.json - <<HEREDOC
+project        : "$GKE_PROJECT"
+location       : "$GKE_LOCATION"
+node_pool_name : "$GKE_CLUSTER_NAME"
+instance_count : "$GKE_NODE_COUNT"
+preemptible    : "$GKE_PREEMPTIBLE"
+vm_type        : "UBUNTU"
+gke_sa_key     : "$GKE_CRED_JSON"
+gcp_dns_sa_key : "$GKE_DNSCRED_JSON"
+cluster_labels :
+    catapult-clustername: "$GKE_CLUSTER_NAME"
+    owner : "${OWNER}"
+cluster_name   : "$GKE_CLUSTER_NAME"
+k8s_version    : "latest"
 HEREDOC
 
+if [ -n "${EXTRA_LABELS}" ] ; then
+    yq merge --inplace --tojson --prettyPrint --overwrite terraform.tfvars.json \
+        - <<< "cluster_labels: ${EXTRA_LABELS}"
+fi
+
 if [ -n "${GKE_INSTANCE_TYPE}" ] ; then
-    cat >> terraform.tfvars <<EOF
-instance_type   = "$GKE_INSTANCE_TYPE"
-EOF
+    yq write --inplace --tojson --prettyPrint terraform.tfvars.json \
+        instance_type "${GKE_INSTANCE_TYPE}"
 fi
 
 if [ -n "${TF_KEY}" ] ; then

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -24,7 +24,7 @@ tearDown() {
 # Tests creation and deletion of build directory
 testBuilddir() {
   rm -rf buildtest
-  make buildir
+  BACKEND="" make buildir
   assertTrue 'create buildir' "[ -d 'buildtest' ]"
   ENVRC="$(cat "$PWD"/buildtest/.envrc)"
   assertContains 'contains KUBECONFIG' "$ENVRC" "KUBECONFIG=\"$PWD/buildtest\"/kubeconfig"


### PR DESCRIPTION
Being able to add extra labels would be useful for CI (in particular, making it easier for CI to find its builds and which build maps to which cluster).

This is in support of https://github.com/cloudfoundry-incubator/kubecf/issues/1144 to get GitHub Actions to work better for KubeCF.