### PR TITLE
fix: GKE: instance type override is not JSON

### DIFF
--- a/backend/gke/tfsetup.sh
+++ b/backend/gke/tfsetup.sh
@@ -37,14 +37,14 @@ cat > terraform.tfvars.json <<HEREDOC
 HEREDOC
 
 if [ -n "${EXTRA_LABELS}" ] ; then
-    jq --raw-output --argjson labels "${EXTRA_LABELS}" '.cluster_labels *= $labels' terraform.tfvars.json \
-        > terraform.tfvars.temp.json
+    jq --monochrome-output --argjson labels "${EXTRA_LABELS}" \
+        '.cluster_labels *= $labels' terraform.tfvars.json > terraform.tfvars.temp.json
     mv terraform.tfvars.temp.json terraform.tfvars.json
 fi
 
 if [ -n "${GKE_INSTANCE_TYPE}" ] ; then
-    jq --argjson type "${GKE_INSTANCE_TYPE}" '.instance_type = $type' terraform.tfvars.json \
-        > terraform.tfvars.temp.json
+    jq --monochrome-output --arg type "${GKE_INSTANCE_TYPE}" \
+        '.instance_type = $type' terraform.tfvars.json > terraform.tfvars.temp.json
     mv terraform.tfvars.temp.json terraform.tfvars.json
 fi
 


### PR DESCRIPTION
This was a copy-and-paste error while fixing `EXTRA_LABELS`; the instance type is a string, not a JSON serialization.

Also fix the output type: we don't want `--raw-output`, since we always want JSON output instead.  That really wasn't an issue, though, as the output was a dict.