### PR TITLE
Add all needed targets to perform airgap installs on GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ module-experimental-eirinifs:
 module-experimental-eirini_release:
 	$(MAKE) -C modules/experimental eirini_release
 
+.PHONY: module-experimental-local-registry
+module-experimental-local-registry:
+	$(MAKE) -C modules/experimental local-registry
+
 .PHONY: module-experimental-airgap-up
 module-experimental-airgap-up:
 	$(MAKE) -C modules/experimental airgap-up

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,10 @@ module-experimental-eirini_release:
 module-experimental-local-registry:
 	$(MAKE) -C modules/experimental local-registry
 
+.PHONY: module-experimental-push-imagelist
+module-experimental-push-imagelist:
+	$(MAKE) -C modules/experimental push-imagelist
+
 .PHONY: module-experimental-airgap-up
 module-experimental-airgap-up:
 	$(MAKE) -C modules/experimental airgap-up

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,10 @@ module-experimental-local-registry:
 module-experimental-push-imagelist:
 	$(MAKE) -C modules/experimental push-imagelist
 
+.PHONY: module-experimental-podman-imagelist
+module-experimental-podman-imagelist:
+	$(MAKE) -C modules/experimental podman-imagelist
+
 .PHONY: module-experimental-airgap-up
 module-experimental-airgap-up:
 	$(MAKE) -C modules/experimental airgap-up

--- a/backend/aks/Makefile
+++ b/backend/aks/Makefile
@@ -35,3 +35,7 @@ all::
 	@echo 'WARNING: stil WIP. Use it on your own risk.'
 	@echo 'Kindly waiting for 5s…'; sleep 5
 all:: deploy
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/backend/caasp4os/Makefile
+++ b/backend/caasp4os/Makefile
@@ -36,3 +36,7 @@ force-clean-cluster:
 
 .PHONY: all
 all: deps-caasp4os caasp4os-deploy caasp-prepare
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/backend/ekcp/Makefile
+++ b/backend/ekcp/Makefile
@@ -36,3 +36,7 @@ force-clean-cluster:
 
 .PHONY: all
 all: up kubeconfig prepare
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/backend/eks/Makefile
+++ b/backend/eks/Makefile
@@ -32,3 +32,7 @@ force-clean-cluster:
 
 .PHONY: all
 all: deploy
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/backend/gke/Makefile
+++ b/backend/gke/Makefile
@@ -30,3 +30,11 @@ force-clean-cluster:
 
 .PHONY: all
 all: deploy
+
+.PHONY: airgap-up
+airgap-up:
+	./airgap-up.sh
+
+.PHONY: airgap-down
+airgap-down:
+	./airgap-down.sh

--- a/backend/gke/airgap-down.sh
+++ b/backend/gke/airgap-down.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+export KUBECF_NAMESPACE=scf
+export QUARKS_NAMESPACE=cf-operator
+gke_isolate_network 0

--- a/backend/gke/airgap-up.sh
+++ b/backend/gke/airgap-up.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+export KUBECF_NAMESPACE=scf
+export QUARKS_NAMESPACE=cf-operator
+for ns in $KUBECF_NAMESPACE $QUARKS_NAMESPACE default; do
+    kubectl create namespace $ns || true
+    kubectl label namespaces --overwrite $ns airgap=true
+done
+
+gke_isolate_network 1

--- a/backend/kind/Makefile
+++ b/backend/kind/Makefile
@@ -54,3 +54,7 @@ stop:
 .PHONY: restart
 restart:
 	./restart.sh
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/backend/minikube/Makefile
+++ b/backend/minikube/Makefile
@@ -38,3 +38,7 @@ start:
 .PHONY: stop
 stop:
 	./stop.sh
+
+.PHONY: airgap-up airgap-down
+airgap-up airgap-down:
+	echo "Not implemented yet" && exit 1

--- a/modules/experimental/Makefile
+++ b/modules/experimental/Makefile
@@ -22,7 +22,7 @@ podman-imagelist:
 	./podman-imagelist.sh
 
 .PHONY: airgap-up
-airgap-up: airgap-down
+airgap-up:
 	./airgap_up.sh
 
 PHONY: airgap-down

--- a/modules/experimental/Makefile
+++ b/modules/experimental/Makefile
@@ -9,6 +9,10 @@ eirini_release:
 eirinifs:
 	./eirinifs.sh
 
+.PHONY: local-registry
+local-registry:
+	./local-registry.sh
+
 .PHONY: airgap-up
 airgap-up: airgap-down
 	./airgap_up.sh

--- a/modules/experimental/Makefile
+++ b/modules/experimental/Makefile
@@ -13,6 +13,10 @@ eirinifs:
 local-registry:
 	./local-registry.sh
 
+.PHONY: push-imagelist
+push-imagelist:
+	./push-imagelist.sh
+
 .PHONY: airgap-up
 airgap-up: airgap-down
 	./airgap_up.sh

--- a/modules/experimental/Makefile
+++ b/modules/experimental/Makefile
@@ -17,6 +17,10 @@ local-registry:
 push-imagelist:
 	./push-imagelist.sh
 
+.PHONY: podman-imagelist
+podman-imagelist:
+	./podman-imagelist.sh
+
 .PHONY: airgap-up
 airgap-up: airgap-down
 	./airgap_up.sh

--- a/modules/experimental/airgap_down.sh
+++ b/modules/experimental/airgap_down.sh
@@ -34,6 +34,13 @@ sudo -s << 'EOS'
   fi
 EOS
 EOF
+
+  # Remove insecure registry
+  # shellcheck disable=SC2087
+  ssh -T sles@${kube_node} << EOF
+sudo sed 's/^\(CRIO_OPTIONS\s*=\s*\).*$/\1""/' \
+  /etc/sysconfig/crio
+EOF
 }
 
 kube_nodes=$(kubectl get nodes -o json | jq -r '.items[] | .status.addresses[] | select(.type=="InternalIP").address')

--- a/modules/experimental/docker/Dockerfile.skopeo
+++ b/modules/experimental/docker/Dockerfile.skopeo
@@ -1,0 +1,5 @@
+FROM opensuse/leap:latest
+LABEL MAINTAINER="Víctor Cuadrado Juan <vcuadradojuan@suse.com>, Christian Richter <crichter@suse.com>"
+RUN zypper ref \
+  && zypper in -y --no-recommends skopeo \
+  && zypper clean --all

--- a/modules/experimental/local-registry.sh
+++ b/modules/experimental/local-registry.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+info "Creating local registry at local-registry.default.svc.cluster.local…"
+
+kubectl apply -f - <<HEREDOC
+---
+# PVC for local registry service
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-data-pvc
+  labels:
+    app: local-registry
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+---
+# Docker registry pod definition
+apiVersion: v1
+kind: Pod
+metadata:
+  name: local-registry
+  labels:
+    app: local-registry
+  namespace: default
+spec:
+  volumes:
+    - name: registry-data-vol
+      persistentVolumeClaim:
+        claimName: registry-data-pvc
+  containers:
+    - name: local-registry
+      image: registry:2
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 5000
+      volumeMounts:
+        - mountPath: /var/lib/registry
+          name: registry-data-vol
+---
+# Registry service definition
+kind: Service
+apiVersion: v1
+metadata:
+  name: local-registry
+  namespace: default
+spec:
+  selector:
+    app: local-registry
+  ports:
+    - port: 80
+      targetPort: 5000
+HEREDOC
+
+wait_ns default
+
+ok "Registry created"
+kubectl get services local-registry -n default

--- a/modules/experimental/podman-imagelist.sh
+++ b/modules/experimental/podman-imagelist.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+info "Starting podman container and copying all imagelist.txt files there"
+
+KUBECF_NAMESPACE=scf
+
+# Create pod, waiting
+kubectl apply --overwrite=false -f - << HEREDOC
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: push-imagelist-pod
+  namespace: scf
+spec:
+  containers:
+    - name: push-imagelist-pod
+      image: greyarch/podman
+      command:
+      - /bin/sh
+      - -c
+      - |
+        mkdir /tmp/kubecf
+        mkdir /tmp/cf-operator
+        echo >> /etc/containers/registries.conf
+        echo '[registries.Insecure]' >> /etc/containers/registries.conf
+        echo "registries = ['local-registry.default.svc.cluster.local']" >> /etc/containers/registries.conf
+        apk add --no-cache skopeo
+        while true; do sleep 100; done
+HEREDOC
+
+# create push-imagelist.sh script
+cat >push-imagelist.sh << 'HEREDOC'
+#!/usr/bin/env sh
+
+set -e
+
+while IFS= read -r file
+do
+    for SOURCE_IMAGE in $(cat "$imagelist_file"); do
+        MIRROR='local-registry.default.svc.cluster.local'
+        echo ">>>>> Mirroring image: ${SOURCE_IMAGE}"
+        # add registry.suse.com/cap/ in front if it's not already there
+        if [[ $( echo $SOURCE_IMAGE | grep -o '/' | tr -d '\r\n' | wc -c) -lt 1 ]]; then
+            # SOURCE_IMAGE=docker.io/"$SOURCE_IMAGE" # upstream
+            SOURCE_IMAGE=registry.suse.com/cap/$SOURCE_IMAGE # cap
+        fi
+
+        org=$(echo "$SOURCE_IMAGE" | cut -d/ -f2)
+        image=$(echo "$SOURCE_IMAGE" | cut -d/ -f3)
+
+        skopeo copy "docker://${SOURCE_IMAGE}" "docker://${MIRROR}/${org}/${image} 2>&1 >/dev/null" &
+    done
+done <  <(find . -name "imagelist.txt")
+
+
+wait
+echo
+echo "Done pushing images"
+HEREDOC
+chmod +x push-imagelist.sh
+
+# wait for the pod to be up
+sleep 30
+
+# copy push-imagelist.sh script
+kubectl cp  push-imagelist.sh "${KUBECF_NAMESPACE}"/push-imagelist-pod:/tmp/push-imagelist.sh
+
+# copy all imagelist.txt files
+while IFS= read -r imagelist_file
+do
+    kubectl cp -n "${KUBECF_NAMESPACE}" "$imagelist_file" \
+            "${KUBECF_NAMESPACE}"/push-imagelist-pod:/tmp/"$imagelist_file"
+done <  <(find . -name "imagelist.txt")
+
+# start the script in the pod
+# TODO
+# for now, just cd tmp; ./push-imagelist.sh

--- a/modules/experimental/push-imagelist.sh
+++ b/modules/experimental/push-imagelist.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+. ./defaults.sh
+. ../../include/common.sh
+. .envrc
+
+info "Pushing all imagelist.txt images to local-registry.default.svc.cluster.local"
+
+kubectl create namespace push-imagelist 2>/dev/null || true
+
+# POSIX compliant:
+while IFS= read -r imagelist_file
+do
+    # Create a kube job per image in imagelist.txt. There, pull it, retag it,
+    # and push the image to the local registry
+    for SOURCE_IMAGE in $(cat "$imagelist_file"); do
+        JOB_NAME=${SOURCE_IMAGE%%\:*} # remove suffix after ':'
+        JOB_NAME=${JOB_NAME////-} # substitute '/' with '-'
+        JOB_NAME=${JOB_NAME:0:63} # truncate to 63 charts for kubernetes
+        TARGET_REGISTRY='local-registry.default.svc.cluster.local'
+        kubectl apply --overwrite=false -f - <<HEREDOC
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: push-imagelist
+spec:
+  template:
+    spec:
+      containers:
+      - name: copy-image
+        image: dragonchaser/opensuse-skopeo:latest
+        command:
+        - /bin/sh
+        - -cex
+        - |
+          echo >> /etc/containers/registries.conf
+          echo '[registries.Insecure]' >> /etc/containers/registries.conf
+          echo "registries = ['${TARGET_REGISTRY}']" >> /etc/containers/registries.conf
+
+          # add registry.suse.com/cap/ in front if it's not already there
+          if [[ $( echo "$SOURCE_IMAGE" | grep -o '/' | tr -d '\r\n' | wc -c) -lt 1 ]]; then
+              # SOURCE_IMAGE=docker.io/"$SOURCE_IMAGE" # upstream
+              SOURCE_IMAGE=registry.suse.com/cap/$SOURCE_IMAGE # cap
+          fi
+
+          org=\$(echo \$SOURCE_IMAGE | cut -d/ -f2)
+          image=\$(echo \$SOURCE_IMAGE | cut -d/ -f3)
+
+          echo "Mirroring image \$SOURCE_IMAGE to ${TARGET_REGISTRY}"
+          skopeo copy "docker://\${SOURCE_IMAGE}" "docker://${TARGET_REGISTRY}/\$org/\$image"
+          echo "Mirrored image \$SOURCE_IMAGE in ${TARGET_REGISTRY}"
+      restartPolicy: Never
+  backoffLimit: 4
+HEREDOC
+    done
+done <  <(find . -name "imagelist.txt")
+
+info "Waiting for jobs to finish pushing images…"
+kubectl -n push-imagelist wait --for=condition=complete job --all --timeout=-1s
+
+ok "All images pushed to local-registry.default.svc.cluster.local"


### PR DESCRIPTION
This PR enables setting up airgapped clusters on GKE for testing. It contains
targets for setting up a local-registry, pushing the images to the registry, and
airgapping the cluster via k8s networkPolicies.

Their implementation has been consciously made to be BACKEND-independent.

Prerequisites for full airgap installations:
- k8s networking plugin installed (for now, only GKE cluster).
- insecure container registries in k8s internal network accepted (for now, only
  GKE cluster).

Included in this PR:

- Add BACKEND-side targets `airgap-up` and `airgap-down` for GKE and stubs for
  the rest of backends. Those targets can be expanded in the future when each
  backend satisfies the prerequisites.

- Add networkPolicies for isolating the cluster by only allowing network
  connections in the internal network, and external connections on DNS ports,
  for anything on the `default`, `scf`, and `cf-operator` namespaces.
  This network policies are backend-independent, but they need a k8s Network
  plugin present. At the moment, only GKE gets deployed with such, in that case,
  Calico.

- Add a `module-experimental-local-registry` target. This target deploys a
  Docker v2 registry as a service in ns `default`, only exposing it internally
  to the cluster via the ClusterIP and the default
  local-registry.default.svc.cluster.local DNS name. For Kubelet to correctly
  pull images from the local registry, one needs to target its ClusterIP.
  
- Add a `module-experimental-push-imagelist` target. This target copies all
  images listed in any imagelist.txt file in the buildfolder into the local
  registry. This is done by spawning 1 k8s job per image to copy, and waiting
  for all jobs to finish successfully.
  We are using dragonchaser/opensuse-skopeo:latest image, which contains
  podman (with vfs for unpriviliged containers), and skopeo.

- Add a `module-experimental-podman-imagelist` target. This target spawns a pod
  with podman configured with vfs for unprivileged containers, and the
  imagelist.txt files and a testing script inside the /tmp/ folder. Only useful
  for manual testing and developing the airgap.
