### PR TITLE
changes helm-inspect for cfo charts from appversion to version

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -287,7 +287,7 @@ function helm_ls {
 # Given a chart path in $1, find its app version
 function helm_chart_app_version {
     # helm 3 aliases "inspect" to "show", so the syntax is the same for 2 & 3.
-    helm inspect chart "${1}" | yq read - appVersion
+    helm inspect chart "${1}" | yq read - version
 }
 
 function wait_for {

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -43,10 +43,15 @@ operator_install_args=(
     --set "operator-webhook-use-service-reference=true"
     --set "customResources.enableInstallation=true"
 )
+info "operator_version: ${operator_version}"
 if [[ "${operator_version%%.*}" -ge 5 ]]; then
+    info "operator_version is greater than 5"
+    info "setting param global.singleNamespace.name"
     operator_install_args+=(--set "global.singleNamespace.name=scf")
 else
     # quarks-operator 4.x uses a different key to target namespace to watch
+    info "operator_version is less than 5"
+    info "setting param global.operator.watchNamespace"
     operator_install_args+=(--set "global.operator.watchNamespace=scf")
 fi
 


### PR DESCRIPTION
use `version` instead of `appversion` to check cfo version

Test: https://concourse.suse.dev/teams/main/pipelines/prabal-gke-upgrades/jobs/pre-upgrade-deploy-kubecf-diego-gke-sa/builds/11