### PR TITLE
Don't remove KubeCF's ns manually, let quarks-operator do it

### DIFF
--- a/modules/kubecf/clean.sh
+++ b/modules/kubecf/clean.sh
@@ -25,9 +25,6 @@ fi
 if helm_ls 2>/dev/null | grep -qi susecf-scf ; then
     helm_delete susecf-scf --namespace scf
 fi
-if kubectl get namespaces 2>/dev/null | grep -qi scf ; then
-    kubectl delete --ignore-not-found namespace scf
-fi
 
 if kubectl get psp 2>/dev/null | grep -qi susecf-scf ; then
     kubectl delete --ignore-not-found psp susecf-scf-default


### PR DESCRIPTION
quarks-operator deletes the ns that is watching on its own, don't remove it manually.

Closes https://github.com/SUSE/catapult/issues/324