### PR TITLE
wait_for_scf: make sure api is running, and ig jobs are gone

### DIFF
--- a/include/func.sh
+++ b/include/func.sh
@@ -218,8 +218,8 @@ function wait_container_attached {
 # See wait_for_kubecf() below for a usage example, and why all this is needed.
 function wait_ns {
     local NAMESPACE=$1
-    local MUSTHAVE=$2
-    local MUSTNOT=$3
+    local MUSTHAVE=${2:-}
+    local MUSTNOT=${3:-}
 
     while true; do
         local output

--- a/include/func.sh
+++ b/include/func.sh
@@ -211,6 +211,11 @@ function wait_container_attached {
     done
 }
 
+# wait_ns NAMESPACE MUSTHAVE MUSTNOT
+# wait_ns waits for all pods in the NAMESPACE to be running or completed (and all containers to be running).
+# It also waits until an instance of the MUSTHAVE pod exist (if non-blank), and that no instances of MUSTNOT
+# exist (again, if non-blank). Only a single pod name is allowed for each of MUSTHAVE and MUSTNOT.
+# See wait_for_kubecf() below for a usage example, and why all this is needed.
 function wait_ns {
     local NAMESPACE=$1
     local MUSTHAVE=$2
@@ -397,7 +402,7 @@ wait_for_cf-operator() {
       # qstate_tolerations fails when internet connectivity is disabled.
       wait_for "kubectl apply -f ../kube/cf-operator/qstatefulset_tolerations.yaml --namespace=scf"
     fi
-    wait_for_scf
+    wait_for_kubecf
     #wait_for "kubectl delete -f ../kube/cf-operator/boshdeployment.yaml --namespace=scf"
     wait_for "kubectl delete -f ../kube/cf-operator/password.yaml --namespace=scf"
     if [[ "${DOCKER_REGISTRY}" == "registry.suse.com" ]]; then
@@ -405,7 +410,7 @@ wait_for_cf-operator() {
     fi
 }
 
-wait_for_scf() {
+wait_for_kubecf() {
     # There can be a brief moment when the "ig" job has terminated, but none of the
     # stateful sets have created a pod yet, where everything within the namespace
     # seems to be ready. That's why we also have to wait for the "api" pod to exist.

--- a/modules/experimental/eirini_release.sh
+++ b/modules/experimental/eirini_release.sh
@@ -114,4 +114,4 @@ openssl req -newkey rsa:4096 -nodes -sha256 -keyout domain.key -x509 -days 365 -
 kubectl create namespace "scf" || true
 helm_install eirini cf/ --namespace scf --values eirini-values.yaml --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=$(cat domain.key)" --set "eirini.secrets.BITS_TLS_CRT=$(cat domain.crt)"
 
-wait_ns scf
+wait_for_scf

--- a/modules/experimental/eirini_release.sh
+++ b/modules/experimental/eirini_release.sh
@@ -114,4 +114,4 @@ openssl req -newkey rsa:4096 -nodes -sha256 -keyout domain.key -x509 -days 365 -
 kubectl create namespace "scf" || true
 helm_install eirini cf/ --namespace scf --values eirini-values.yaml --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=$(cat domain.key)" --set "eirini.secrets.BITS_TLS_CRT=$(cat domain.crt)"
 
-wait_for_scf
+wait_for_kubecf

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -87,6 +87,6 @@ helm_install susecf-scf ${SCF_CHART} \
 
 sleep 540
 
-wait_ns scf
+wait_for_scf
 
 ok "KubeCF deployed successfully"

--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -87,6 +87,6 @@ helm_install susecf-scf ${SCF_CHART} \
 
 sleep 540
 
-wait_for_scf
+wait_for_kubecf
 
 ok "KubeCF deployed successfully"

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -30,7 +30,7 @@ helm_upgrade susecf-scf kubecf/ \
              --values scf-config-values.yaml
 sleep 10
 
-wait_for_scf
+wait_for_kubecf
 
 ok "KubeCF deployment upgraded successfully"
 helm list -A

--- a/modules/kubecf/upgrade.sh
+++ b/modules/kubecf/upgrade.sh
@@ -30,7 +30,7 @@ helm_upgrade susecf-scf kubecf/ \
              --values scf-config-values.yaml
 sleep 10
 
-wait_ns scf
+wait_for_scf
 
 ok "KubeCF deployment upgraded successfully"
 helm list -A


### PR DESCRIPTION
There can be a brief moment when the "ig" job has terminated, but none of the stateful sets have created a pod yet, where everything within the namespace seems to be ready. That's why we also have to wait for the "api" pod to exist.

There is a different scenario when one or more "ig" jobs have been launched by quarks, and they seem to be in "completed" status and everything appears to be "ready". But then one of the "ig" jobs restarts and terminates all the scf pods again. So we need to wait until all the "ig" jobs are gone.
