### PR TITLE
Check for system:metrics-server cluster role and not for helm release

### DIFF
--- a/modules/kubecf/install.sh
+++ b/modules/kubecf/install.sh
@@ -7,7 +7,7 @@
 
 if [[ $ENABLE_EIRINI == true ]] ; then
    # [ ! -f "helm/cf/templates/eirini-namespace.yaml" ] && kubectl create namespace eirini
-    if ! helm_ls 2>/dev/null | grep -qi metrics-server ; then
+    if ! kubectl get clusterrole system:metrics-server &> /dev/null; then
         helm_install metrics-server stable/metrics-server\
              --set args[0]="--kubelet-preferred-address-types=InternalIP" \
              --set args[1]="--kubelet-insecure-tls" || true


### PR DESCRIPTION
metrics-server seems to be pre-installed in GKE now, but not via helm chart, and creating a cluster role that already exists fails.
